### PR TITLE
Hiera does not handle boolean/numeric values correctly, and instead returns nil/null for them

### DIFF
--- a/lib/hiera/backend.rb
+++ b/lib/hiera/backend.rb
@@ -105,7 +105,9 @@ class Hiera
             # Ultimately it just pass the data through parse_string but
             # it makes some effort to handle arrays of strings as well
             def parse_answer(data, scope, extra_data={})
-                if data.is_a?(String)
+                if data.is_a?(Numeric) or data.is_a?(TrueClass) or data.is_a?(FalseClass)
+                    return data
+                elsif data.is_a?(String)
                     return parse_string(data, scope, extra_data)
                 elsif data.is_a?(Hash)
                     answer = {}

--- a/spec/unit/backend_spec.rb
+++ b/spec/unit/backend_spec.rb
@@ -156,6 +156,26 @@ class Hiera
                 input = {"foo" => "test_%{rspec}_test", "bar" => ["test_%{rspec}_test", "test_%{rspec}_test"]}
                 Backend.parse_answer(input, {"rspec" => "test"}).should == {"foo"=>"test_test_test", "bar"=>["test_test_test", "test_test_test"]}
             end
+            
+            it "should parse integers correctly" do
+              input = 1
+              Backend.parse_answer(input, {"rspec" => "test"}).should == 1
+            end
+            
+            it "should parse floats correctly" do
+              input = 0.233
+              Backend.parse_answer(input, {"rspec" => "test"}).should == 0.233
+            end
+            
+            it "should parse true boolean values correctly" do
+              input = true
+              Backend.parse_answer(input, {"rspec" => "test"}).should == true
+            end
+            
+            it "should parse false boolean values correctly" do
+              input = false
+              Backend.parse_answer(input, {"rspec" => "test"}).should == false
+            end
         end
 
         describe "#resolve_answer" do


### PR DESCRIPTION
At present, if you have a YAML or JSON file that contains numeric values (integers or floats), or booleans, then Hiera will hose these when they're returned - you end up with null.

Because I see no reason not to support these data types, this pull request adds support for them in to `parse_answer`, for which it simply returns the value.
