### PR TITLE
(#13) Hierarchy includes sub-hierarchy

### DIFF
--- a/lib/hiera/backend.rb
+++ b/lib/hiera/backend.rb
@@ -67,7 +67,7 @@ class Hiera
 
                 hierarchy.flatten.map do |source|
                     source = parse_string(source, scope)
-                    yield(source) unless source == ""
+                    yield(source) unless source == "" or source =~ /(^\/|\/\/|\/$)/
                 end
             end
 


### PR DESCRIPTION
Any time a hierarchy has multiple levels as directories, ie
 #{country}/#{dc}/#{fqdn} and one of the levels is not defined, we do not
want to process this in hiera. If any level of one line is undefined,
that line will either end with /, begin with /, or have // in the middle
somewhere, and we don't want to look up data files for that.

This regex just checks for that before yielding to the backend.
