### PR TITLE
Fix warnings for rake

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,5 @@
 require 'rubygems'
-require 'rake/gempackagetask'
+require 'rubygems/package_task'
 require 'rspec/core/rake_task'
 
 spec = Gem::Specification.new do |s|
@@ -18,7 +18,7 @@ spec = Gem::Specification.new do |s|
   s.default_executable = "hiera"
 end
 
-Rake::GemPackageTask.new(spec) do |pkg|
+Gem::PackageTask.new(spec) do |pkg|
   pkg.need_tar = true
 end
 


### PR DESCRIPTION
The rake had this warning: `rake/gempackagetask is deprecated.  Use rubygems/package_task instead`

This commit fixes this behaviour.
