### PR TITLE
Switch branding to Puppet Labs

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2010, 2011 R.I.Pienaar
+   Copyright 2010, 2011 R.I.Pienaar, Puppet Labs
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/Rakefile
+++ b/Rakefile
@@ -5,9 +5,9 @@ require 'rspec/core/rake_task'
 spec = Gem::Specification.new do |s|
   s.name = "hiera"
   s.version = "0.2.0"
-  s.author = "R.I.Pienaar"
-  s.email = "rip@devco.net"
-  s.homepage = "https://github.com/ripienaar/hiera/"
+  s.author = "Puppet Labs"
+  s.email = "info@puppetlabs.com"
+  s.homepage = "https://github.com/puppetlabs/hiera/"
   s.summary = "Light weight hierarcical data store"
   s.description = "A pluggable data store for hierarcical data"
   s.files = FileList["{bin,lib}/**/*"].to_a


### PR DESCRIPTION
Modifies the COPYING and Rakefile to brand the Hiera project as Puppet
Labs.

Thanks to RI for the project.

Signed-off-by: Michael Stahnke stahnma@puppetlabs.com
