### PR TITLE
rspec 2.7 compatiblity fix

### DIFF
--- a/spec/unit/backend/yaml_backend_spec.rb
+++ b/spec/unit/backend/yaml_backend_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../../spec_helper'
+require 'spec_helper'
 
 require 'hiera/backend/yaml_backend'
 

--- a/spec/unit/backend_spec.rb
+++ b/spec/unit/backend_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../spec_helper'
+require 'spec_helper'
 
 class Hiera
     describe Backend do

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../spec_helper'
+require 'spec_helper'
 
 class Hiera
     describe Config do

--- a/spec/unit/console_logger_spec.rb
+++ b/spec/unit/console_logger_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../spec_helper'
+require 'spec_helper'
 
 class Hiera
     describe Console_logger do

--- a/spec/unit/hiera_spec.rb
+++ b/spec/unit/hiera_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../spec_helper'
+require 'spec_helper'
 
 describe "Hiera" do
     describe "#logger=" do


### PR DESCRIPTION
Rspec 2.7 has introduced some non backwards compatible changes
that is exposed by using require with full paths.

Simplify the requires to use the ruby lib search order instead
which resolves these
