### PR TITLE
Change Rakefile to autoversion

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,10 +1,12 @@
 require 'rubygems'
 require 'rubygems/package_task'
 require 'rspec/core/rake_task'
+require 'tasks/release.rb'
 
 spec = Gem::Specification.new do |s|
   s.name = "hiera"
-  s.version = "0.2.0"
+  # Tag the version you want to release via an annotated tag
+  s.version = described_version
   s.author = "Puppet Labs"
   s.email = "info@puppetlabs.com"
   s.homepage = "https://github.com/puppetlabs/hiera/"

--- a/tasks/release.rb
+++ b/tasks/release.rb
@@ -1,0 +1,33 @@
+
+VERSION_FILE = 'lib/hiera.rb'
+
+def get_current_version
+  File.open( VERSION_FILE ) {|io| io.grep(/VERSION = /)}[0].split()[-1]
+end
+
+def described_version
+    # This ugly bit removes the gSHA1 portion of the describe as that causes failing tests
+    %x{git describe}.gsub('-', '.').split('.')[0..3].join('.').to_s
+end
+
+namespace :pkg do
+
+  desc "Bump version prior to release (internal task)"
+  task :versionbump  do
+    old_version =  get_current_version
+    contents = IO.read(VERSION_FILE)
+    contents.gsub!("VERSION = #{old_version}", "VERSION = #{described_version}")
+    file = File.open(VERSION_FILE, 'w')
+    file.write contents
+    file.close
+  end
+
+  desc "Build Package"
+  task :release => [ :versionbump, :default ] do
+    Rake::Task[:package].invoke
+  end
+
+end # namespace
+
+task :clean => [ :clobber_package ] do
+end


### PR DESCRIPTION
This change modifies the Rakefile to derrive the version of the package
based on a call to "git describe."

git describe will show the current annotated tag or the
tag-commits-gSHA1 as the version string. Due to the way gem processes
version strings, the Rakefile replaces '-' with '.'

So, the new release process would be:
  tag (signed), rake default

Future enhancements may add a task for uploads to the puppetlabs
downloads area.

Note: to test I tagged the first commit as 0.0.1.
Other options would be to retag the released versions with signed
tags.

Signed-off-by: Michael Stahnke stahnma@puppetlabs.com
