### PR TITLE
Fixes a quoting string issue

### DIFF
--- a/tasks/release.rb
+++ b/tasks/release.rb
@@ -7,7 +7,7 @@ end
 
 def described_version
     # This ugly bit removes the gSHA1 portion of the describe as that causes failing tests
-    %x{git describe}.gsub('-', '.').split('.')[0..3].join('.').to_s
+    %x{git describe}.gsub('-', '.').split('.')[0..3].join('.').to_s.gsub('v', '')
 end
 
 namespace :pkg do
@@ -16,7 +16,8 @@ namespace :pkg do
   task :versionbump  do
     old_version =  get_current_version
     contents = IO.read(VERSION_FILE)
-    contents.gsub!("VERSION = #{old_version}", "VERSION = #{described_version}")
+    new_version = '"' + described_version.to_s.strip + '"'
+    contents.gsub!("VERSION = #{old_version}", "VERSION = #{new_version}")
     file = File.open(VERSION_FILE, 'w')
     file.write contents
     file.close


### PR DESCRIPTION
The gsub wasn't always working when the tag wasn't being quoted properly
in the sub inside hiera.rb.  This commit ensures the version is quoted.

It will also strip the leading 'v' from tag to make the version
completely numeric.

Signed-off-by: Michael Stahnke stahnma@puppetlabs.com
