### PR TITLE
match data in puppet ${::fact} style to get rid of puppet deprecation warnings

### DIFF
--- a/lib/hiera/backend.rb
+++ b/lib/hiera/backend.rb
@@ -87,20 +87,22 @@ class Hiera
 
         if tdata.is_a?(String)
           while tdata =~ /%\{(.+?)\}/
-            var = $1
+            begin
+              var = $1
 
-            val = ""
+              val = ""
 
-            # Puppet can return :undefined for unknown scope vars,
-            # If it does then we still need to evaluate extra_data
-            # before returning an empty string.
-            if scope[var] && scope[var] != :undefined
-                val = scope[var]
-            elsif extra_data[var]
-                val = extra_data[var]
-            end
+              # Puppet can return :undefined for unknown scope vars,
+              # If it does then we still need to evaluate extra_data
+              # before returning an empty string.
+              if scope[var] && scope[var] != :undefined
+                  val = scope[var]
+              elsif extra_data[var]
+                  val = extra_data[var]
+              end
+            end until val != "" || var !~ /::(.+)/
 
-            tdata.gsub!(/%\{#{var}\}/, val)
+            tdata.gsub!(/%\{(::)?#{var}\}/, val)
           end
         end
 

--- a/spec/unit/backend_spec.rb
+++ b/spec/unit/backend_spec.rb
@@ -140,6 +140,10 @@ class Hiera
         Backend.parse_string(input, {"rspec" => :undefined}, {"rspec" => "test"}).should == "test_test_test"
       end
 
+      it "should match data in puppet ${::fact} style" do
+        input = "test_%{::rspec}_test"
+        Backend.parse_string(input, {"rspec" => "test"}).should == "test_test_test"
+      end
     end
 
     describe "#parse_answer" do


### PR DESCRIPTION
Puppet facts go into inventory in ${fact} format whereas puppet itself throws warnings on using variables in that form instead of ${::fact}.

This commit fixes that.
