### PR TITLE
(maint) Code base cleanup, use 2 space indention.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -26,8 +26,8 @@ end
 
 desc "Run all specs"
 RSpec::Core::RakeTask.new(:test) do |t|
-    t.pattern = 'spec/**/*_spec.rb'
-    t.rspec_opts = File.read("spec/spec.opts").chomp || ""
+  t.pattern = 'spec/**/*_spec.rb'
+  t.rspec_opts = File.read("spec/spec.opts").chomp || ""
 end
 
 task :default => [:test, :repackage]

--- a/bin/hiera
+++ b/bin/hiera
@@ -18,152 +18,152 @@ require 'optparse'
 options = {:default => nil, :config => "/etc/hiera.yaml", :scope => {}, :key => nil, :verbose => false, :resolution_type => :priority}
 
 class Hiera::Noop_logger
-    class << self
-        def warn(msg);end
-        def debug(msg);end
-    end
+  class << self
+    def warn(msg);end
+    def debug(msg);end
+  end
 end
 
 # Loads the scope from YAML or JSON files
 def load_scope(source, type=:yaml)
-    case type
-    when :mcollective
-        begin
-            require 'mcollective'
+  case type
+  when :mcollective
+    begin
+      require 'mcollective'
 
-            include MCollective::RPC
+      include MCollective::RPC
 
-            util = rpcclient("rpcutil")
-            util.progress = false
-            nodestats = util.custom_request("inventory", {}, source, {"identity" => source}).first
+      util = rpcclient("rpcutil")
+      util.progress = false
+      nodestats = util.custom_request("inventory", {}, source, {"identity" => source}).first
 
-            raise "Failed to retrieve facts for node #{source}: #{nodestats[:statusmsg]}" unless nodestats[:statuscode] == 0
+      raise "Failed to retrieve facts for node #{source}: #{nodestats[:statusmsg]}" unless nodestats[:statuscode] == 0
 
-            scope = nodestats[:data][:facts]
-        rescue Exception => e
-            STDERR.puts "MCollective lookup failed: #{e.class}: #{e}"
-            exit 1
-        end
-
-    when :yaml
-        raise "Cannot find scope #{type} file #{source}" unless File.exist?(source)
-
-        require 'yaml'
-
-        # Attempt to load puppet in case we're going to be fed
-        # Puppet yaml files
-        begin
-            require 'puppet'
-        rescue
-        end
-
-        scope = YAML.load_file(source)
-
-        # Puppet makes dumb yaml files that do not promote data reuse.
-        scope = scope.values if scope.is_a?(Puppet::Node::Facts)
-
-    when :json
-        raise "Cannot find scope #{type} file #{source}" unless File.exist?(source)
-
-        require 'json'
-
-        scope = JSON.load(File.read(source))
-
-    when :inventory_service
-        # For this to work the machine running the hiera command needs access to
-        # /facts REST endpoint on your inventory server.  This access is
-        # controlled in auth.conf and identification is by the certname of the
-        # machine running hiera commands.
-        #
-        # Another caveat is that if your inventory server isn't at the short dns
-        # name of 'puppet' you will need to set the inventory_sever option in
-        # your puppet.conf.  Set it in either the master or main sections.  It
-        # is fine to have the inventory_server option set even if the config
-        # doesn't have the fact_terminus set to rest.
-        begin
-          require 'puppet/util/run_mode'
-          $puppet_application_mode = Puppet::Util::RunMode[:master]
-          require 'puppet'
-          Puppet.settings.parse
-          Puppet::Node::Facts.indirection.terminus_class = :rest
-          scope = YAML.load(Puppet::Node::Facts.indirection.find(source).to_yaml)
-          # Puppet makes dumb yaml files that do not promote data reuse.
-          scope = scope.values if scope.is_a?(Puppet::Node::Facts)
-        rescue Exception => e
-            STDERR.puts "Puppet inventory service lookup failed: #{e.class}: #{e}"
-            exit 1
-        end
-    else
-        raise "Don't know how to load data type #{type}"
+      scope = nodestats[:data][:facts]
+    rescue Exception => e
+      STDERR.puts "MCollective lookup failed: #{e.class}: #{e}"
+      exit 1
     end
 
-    raise "Scope from #{type} file #{source} should be a Hash" unless scope.is_a?(Hash)
+  when :yaml
+    raise "Cannot find scope #{type} file #{source}" unless File.exist?(source)
 
-    scope
+    require 'yaml'
+
+    # Attempt to load puppet in case we're going to be fed
+    # Puppet yaml files
+    begin
+        require 'puppet'
+    rescue
+    end
+
+    scope = YAML.load_file(source)
+
+    # Puppet makes dumb yaml files that do not promote data reuse.
+    scope = scope.values if scope.is_a?(Puppet::Node::Facts)
+
+  when :json
+    raise "Cannot find scope #{type} file #{source}" unless File.exist?(source)
+
+    require 'json'
+
+    scope = JSON.load(File.read(source))
+
+  when :inventory_service
+    # For this to work the machine running the hiera command needs access to
+    # /facts REST endpoint on your inventory server.  This access is
+    # controlled in auth.conf and identification is by the certname of the
+    # machine running hiera commands.
+    #
+    # Another caveat is that if your inventory server isn't at the short dns
+    # name of 'puppet' you will need to set the inventory_sever option in
+    # your puppet.conf.  Set it in either the master or main sections.  It
+    # is fine to have the inventory_server option set even if the config
+    # doesn't have the fact_terminus set to rest.
+    begin
+      require 'puppet/util/run_mode'
+      $puppet_application_mode = Puppet::Util::RunMode[:master]
+      require 'puppet'
+      Puppet.settings.parse
+      Puppet::Node::Facts.indirection.terminus_class = :rest
+      scope = YAML.load(Puppet::Node::Facts.indirection.find(source).to_yaml)
+      # Puppet makes dumb yaml files that do not promote data reuse.
+      scope = scope.values if scope.is_a?(Puppet::Node::Facts)
+    rescue Exception => e
+        STDERR.puts "Puppet inventory service lookup failed: #{e.class}: #{e}"
+        exit 1
+    end
+  else
+    raise "Don't know how to load data type #{type}"
+  end
+
+  raise "Scope from #{type} file #{source} should be a Hash" unless scope.is_a?(Hash)
+
+  scope
 end
 
 OptionParser.new do |opts|
-    opts.on("--version", "-V", "Version information") do
-        puts Hiera.version
-        exit
-    end
+  opts.on("--version", "-V", "Version information") do
+    puts Hiera.version
+    exit
+  end
 
-    opts.on("--debug", "-d", "Show debugging information") do
-        options[:verbose] = true
-    end
+  opts.on("--debug", "-d", "Show debugging information") do
+    options[:verbose] = true
+  end
 
-    opts.on("--array", "-a", "Array search") do
-        options[:resolution_type] = :array
-    end
+  opts.on("--array", "-a", "Array search") do
+    options[:resolution_type] = :array
+  end
 
-    opts.on("--hash", "-h", "Hash search") do
-        options[:resolution_type] = :hash
-    end
+  opts.on("--hash", "-h", "Hash search") do
+    options[:resolution_type] = :hash
+  end
 
-    opts.on("--config CONFIG", "-c", "Configuration file") do |v|
-        if File.exist?(v)
-            options[:config] = v
-        else
-            STDERR.puts "Cannot find config file: #{v}"
-            exit 1
-        end
+  opts.on("--config CONFIG", "-c", "Configuration file") do |v|
+    if File.exist?(v)
+      options[:config] = v
+    else
+      STDERR.puts "Cannot find config file: #{v}"
+      exit 1
     end
+  end
 
-    opts.on("--json SCOPE", "-j", "JSON format file to load scope from") do |v|
-        begin
-            options[:scope] = load_scope(v, :json)
-        rescue Exception => e
-            STDERR.puts "Could not load JSON scope: #{e.class}: #{e}"
-            exit 1
-        end
+  opts.on("--json SCOPE", "-j", "JSON format file to load scope from") do |v|
+    begin
+      options[:scope] = load_scope(v, :json)
+    rescue Exception => e
+      STDERR.puts "Could not load JSON scope: #{e.class}: #{e}"
+      exit 1
     end
+  end
 
-    opts.on("--yaml SCOPE", "-y", "YAML format file to load scope from") do |v|
-        begin
-            options[:scope] = load_scope(v)
-        rescue Exception => e
-            STDERR.puts "Could not load YAML scope: #{e.class}: #{e}"
-            exit 1
-        end
+  opts.on("--yaml SCOPE", "-y", "YAML format file to load scope from") do |v|
+    begin
+      options[:scope] = load_scope(v)
+    rescue Exception => e
+      STDERR.puts "Could not load YAML scope: #{e.class}: #{e}"
+      exit 1
     end
+  end
 
-    opts.on("--mcollective IDENTITY", "-m", "Retrieve facts from a node via mcollective as scope") do |v|
-        begin
-            options[:scope] = load_scope(v, :mcollective)
-        rescue Exception => e
-            STDERR.puts "Could not load MCollective scope: #{e.class}: #{e}"
-            exit 1
-        end
+  opts.on("--mcollective IDENTITY", "-m", "Retrieve facts from a node via mcollective as scope") do |v|
+    begin
+      options[:scope] = load_scope(v, :mcollective)
+    rescue Exception => e
+      STDERR.puts "Could not load MCollective scope: #{e.class}: #{e}"
+      exit 1
     end
+  end
 
-    opts.on("--inventory_service IDENTITY", "-i", "Retrieve facts for a node via Puppet's inventory service as scope") do |v|
-        begin
-            options[:scope] = load_scope(v, :inventory_service)
-        rescue Exception => e
-            STDERR.puts "Could not load Puppet inventory service scope: #{e.class}: #{e}"
-            exit 1
-        end
+  opts.on("--inventory_service IDENTITY", "-i", "Retrieve facts for a node via Puppet's inventory service as scope") do |v|
+    begin
+      options[:scope] = load_scope(v, :inventory_service)
+    rescue Exception => e
+      STDERR.puts "Could not load Puppet inventory service scope: #{e.class}: #{e}"
+      exit 1
     end
+  end
 end.parse!
 
 # arguments can be:
@@ -172,43 +172,43 @@ end.parse!
 #
 # The var=val's assign scope
 unless ARGV.empty?
-    options[:key] = ARGV.delete_at(0)
+  options[:key] = ARGV.delete_at(0)
 
-    ARGV.each do |arg|
-        if arg =~ /^(.+?)=(.+?)$/
-            options[:scope][$1] = $2
-        else
-            unless options[:default]
-                options[:default] = arg.dup
-            else
-                STDERR.puts "Don't know how to parse scope argument: #{arg}"
-            end
-        end
+  ARGV.each do |arg|
+    if arg =~ /^(.+?)=(.+?)$/
+      options[:scope][$1] = $2
+    else
+      unless options[:default]
+        options[:default] = arg.dup
+      else
+        STDERR.puts "Don't know how to parse scope argument: #{arg}"
+      end
     end
+  end
 else
-    STDERR.puts "Please supply a data item to look up"
-    exit 1
+  STDERR.puts "Please supply a data item to look up"
+  exit 1
 end
 
 begin
-    hiera = Hiera.new(:config => options[:config])
+  hiera = Hiera.new(:config => options[:config])
 rescue Exception => e
-    if options[:verbose]
-        raise
-    else
-        STDERR.puts "Failed to start Hiera: #{e.class}: #{e}"
-        exit 1
-    end
+  if options[:verbose]
+    raise
+  else
+    STDERR.puts "Failed to start Hiera: #{e.class}: #{e}"
+    exit 1
+  end
 end
 
 unless options[:verbose]
-    Hiera.logger = "noop"
+  Hiera.logger = "noop"
 end
 
 ans = hiera.lookup(options[:key], options[:default], options[:scope], nil, options[:resolution_type])
 
 if ans.is_a?(String)
-    puts ans
+  puts ans
 else
-    p ans
+  p ans
 end

--- a/lib/hiera.rb
+++ b/lib/hiera.rb
@@ -2,60 +2,60 @@ require 'rubygems'
 require 'yaml'
 
 class Hiera
-    VERSION = "0.2.1"
+  VERSION = "0.2.1"
 
-    autoload :Config, "hiera/config"
-    autoload :Backend, "hiera/backend"
-    autoload :Console_logger, "hiera/console_logger"
-    autoload :Puppet_logger, "hiera/puppet_logger"
+  autoload :Config, "hiera/config"
+  autoload :Backend, "hiera/backend"
+  autoload :Console_logger, "hiera/console_logger"
+  autoload :Puppet_logger, "hiera/puppet_logger"
 
-    class << self
-        def version
-            VERSION
-        end
-
-        # Loggers are pluggable, just provide a class called
-        # Hiera::Foo_logger and respond to :warn and :debug
-        #
-        # See hiera-puppet for an example that uses the Puppet
-        # loging system instead of our own
-        def logger=(logger)
-            loggerclass = "#{logger.capitalize}_logger"
-
-            require "hiera/#{logger}_logger" unless constants.include?(loggerclass)
-
-            @logger = const_get(loggerclass)
-        rescue Exception => e
-            @logger = Console_logger
-            warn("Failed to load #{logger} logger: #{e.class}: #{e}")
-        end
-
-        def warn(msg); @logger.warn(msg); end
-        def debug(msg); @logger.debug(msg); end
+  class << self
+    def version
+      VERSION
     end
 
-    attr_reader :options, :config
-
-    # If the config option is a string its assumed to be a filename,
-    # else a hash of what would have been in the YAML config file
-    def initialize(options={})
-        options[:config] ||= "/etc/hiera.yaml"
-
-        @config = Config.load(options[:config])
-
-        Config.load_backends
-    end
-
-    # Calls the backends to do the actual lookup.
+    # Loggers are pluggable, just provide a class called
+    # Hiera::Foo_logger and respond to :warn and :debug
     #
-    # The scope can be anything that responds to [], if you have input
-    # data like a Puppet Scope that does not you can wrap that data in a
-    # class that has a [] method that fetches the data from your source.
-    # See hiera-puppet for an example of this.
-    #
-    # The order-override will insert as first in the hierarchy a data source
-    # of your choice.
-    def lookup(key, default, scope, order_override=nil, resolution_type=:priority)
-        Backend.lookup(key, default, scope, order_override, resolution_type)
+    # See hiera-puppet for an example that uses the Puppet
+    # loging system instead of our own
+    def logger=(logger)
+      loggerclass = "#{logger.capitalize}_logger"
+
+      require "hiera/#{logger}_logger" unless constants.include?(loggerclass)
+
+      @logger = const_get(loggerclass)
+    rescue Exception => e
+      @logger = Console_logger
+      warn("Failed to load #{logger} logger: #{e.class}: #{e}")
     end
+
+    def warn(msg); @logger.warn(msg); end
+    def debug(msg); @logger.debug(msg); end
+  end
+
+  attr_reader :options, :config
+
+  # If the config option is a string its assumed to be a filename,
+  # else a hash of what would have been in the YAML config file
+  def initialize(options={})
+    options[:config] ||= "/etc/hiera.yaml"
+
+    @config = Config.load(options[:config])
+
+    Config.load_backends
+  end
+
+  # Calls the backends to do the actual lookup.
+  #
+  # The scope can be anything that responds to [], if you have input
+  # data like a Puppet Scope that does not you can wrap that data in a
+  # class that has a [] method that fetches the data from your source.
+  # See hiera-puppet for an example of this.
+  #
+  # The order-override will insert as first in the hierarchy a data source
+  # of your choice.
+  def lookup(key, default, scope, order_override=nil, resolution_type=:priority)
+    Backend.lookup(key, default, scope, order_override, resolution_type)
+  end
 end

--- a/lib/hiera/backend.rb
+++ b/lib/hiera/backend.rb
@@ -1,174 +1,174 @@
 class Hiera
-    module Backend
-        class << self
-            # Data lives in /var/lib/hiera by default.  If a backend
-            # supplies a datadir in the config it will be used and
-            # subject to variable expansion based on scope
-            def datadir(backend, scope)
-                backend = backend.to_sym
-                default = "/var/lib/hiera"
+  module Backend
+    class << self
+      # Data lives in /var/lib/hiera by default.  If a backend
+      # supplies a datadir in the config it will be used and
+      # subject to variable expansion based on scope
+      def datadir(backend, scope)
+        backend = backend.to_sym
+        default = "/var/lib/hiera"
 
-                if Config.include?(backend)
-                    parse_string(Config[backend][:datadir] || default, scope)
-                else
-                    parse_string(default, scope)
-                end
-            end
-
-            # Finds the path to a datafile based on the Backend#datadir
-            # and extension
-            #
-            # If the file is not found nil is returned
-            def datafile(backend, scope, source, extension)
-                file = File.join([datadir(backend, scope), "#{source}.#{extension}"])
-
-                unless File.exist?(file)
-                    Hiera.debug("Cannot find datafile #{file}, skipping")
-
-                    return nil
-                end
-
-                return file
-            end
-
-            # Returns an appropriate empty answer dependant on resolution type
-            def empty_answer(resolution_type)
-                case resolution_type
-                when :array
-                    return []
-                when :hash
-                    return {}
-                else
-                    return nil
-                end
-            end
-
-            # Constructs a list of data sources to search
-            #
-            # If you give it a specific hierarchy it will just use that
-            # else it will use the global configured one, failing that
-            # it will just look in the 'common' data source.
-            #
-            # An override can be supplied that will be pre-pended to the
-            # hierarchy.
-            #
-            # The source names will be subject to variable expansion based
-            # on scope
-            def datasources(scope, override=nil, hierarchy=nil)
-                if hierarchy
-                    hierarchy = [hierarchy]
-                elsif Config.include?(:hierarchy)
-                    hierarchy = [Config[:hierarchy]].flatten
-                else
-                    hierarchy = ["common"]
-                end
-
-                hierarchy.insert(0, override) if override
-
-                hierarchy.flatten.map do |source|
-                    source = parse_string(source, scope)
-                    yield(source) unless source == "" or source =~ /(^\/|\/\/|\/$)/
-                end
-            end
-
-            # Parse a string like '%{foo}' against a supplied
-            # scope and additional scope.  If either scope or
-            # extra_scope includes the varaible 'foo' it will
-            # be replaced else an empty string will be placed.
-            #
-            # If both scope and extra_data has "foo" scope
-            # will win.  See hiera-puppet for an example of
-            # this to make hiera aware of additional non scope
-            # variables
-            def parse_string(data, scope, extra_data={})
-                return nil unless data
-
-                tdata = data.clone
-
-                if tdata.is_a?(String)
-                    while tdata =~ /%\{(.+?)\}/
-                        var = $1
-                        val = scope[var] || extra_data[var] || ""
-
-                        # Puppet can return this for unknown scope vars
-                        val = "" if val == :undefined
-
-                        tdata.gsub!(/%\{#{var}\}/, val)
-                    end
-                end
-
-                return tdata
-            end
-
-            # Parses a answer received from data files
-            #
-            # Ultimately it just pass the data through parse_string but
-            # it makes some effort to handle arrays of strings as well
-            def parse_answer(data, scope, extra_data={})
-                if data.is_a?(Numeric) or data.is_a?(TrueClass) or data.is_a?(FalseClass)
-                    return data
-                elsif data.is_a?(String)
-                    return parse_string(data, scope, extra_data)
-                elsif data.is_a?(Hash)
-                    answer = {}
-                    data.each_pair do |key, val|
-                        answer[key] = parse_answer(val, scope, extra_data)
-                    end
-
-                    return answer
-                elsif data.is_a?(Array)
-                    answer = []
-                    data.each do |item|
-                        answer << parse_answer(item, scope, extra_data)
-                    end
-
-                    return answer
-                end
-            end
-
-            def resolve_answer(answer, resolution_type)
-                case resolution_type
-                when :array
-                    [answer].flatten.uniq.compact
-                when :hash
-                    answer # Hash structure should be preserved
-                else
-                    answer
-                end
-            end
-
-            # Calls out to all configured backends in the order they
-            # were specified.  The first one to answer will win.
-            #
-            # This lets you declare multiple backends, a possible
-            # use case might be in Puppet where a Puppet module declares
-            # default data using in-module data while users can override
-            # using JSON/YAML etc.  By layering the backends and putting
-            # the Puppet one last you can override module author data
-            # easily.
-            #
-            # Backend instances are cached so if you need to connect to any
-            # databases then do so in your constructor, future calls to your
-            # backend will not create new instances
-            def lookup(key, default, scope, order_override, resolution_type)
-                @backends ||= {}
-                answer = nil
-
-                Config[:backends].each do |backend|
-                    if constants.include?("#{backend.capitalize}_backend")
-                        @backends[backend] ||= Backend.const_get("#{backend.capitalize}_backend").new
-                        answer = @backends[backend].lookup(key, scope, order_override, resolution_type)
-
-                        break if answer
-                    end
-                end
-
-                answer = resolve_answer(answer, resolution_type)
-                answer = parse_string(default, scope) if answer.nil?
-
-                return default if answer == empty_answer(resolution_type)
-                return answer
-            end
+        if Config.include?(backend)
+          parse_string(Config[backend][:datadir] || default, scope)
+        else
+          parse_string(default, scope)
         end
+      end
+
+      # Finds the path to a datafile based on the Backend#datadir
+      # and extension
+      #
+      # If the file is not found nil is returned
+      def datafile(backend, scope, source, extension)
+        file = File.join([datadir(backend, scope), "#{source}.#{extension}"])
+
+        unless File.exist?(file)
+          Hiera.debug("Cannot find datafile #{file}, skipping")
+
+          return nil
+        end
+
+        return file
+      end
+
+      # Returns an appropriate empty answer dependant on resolution type
+      def empty_answer(resolution_type)
+        case resolution_type
+        when :array
+          return []
+        when :hash
+          return {}
+        else
+          return nil
+        end
+      end
+
+      # Constructs a list of data sources to search
+      #
+      # If you give it a specific hierarchy it will just use that
+      # else it will use the global configured one, failing that
+      # it will just look in the 'common' data source.
+      #
+      # An override can be supplied that will be pre-pended to the
+      # hierarchy.
+      #
+      # The source names will be subject to variable expansion based
+      # on scope
+      def datasources(scope, override=nil, hierarchy=nil)
+        if hierarchy
+          hierarchy = [hierarchy]
+        elsif Config.include?(:hierarchy)
+          hierarchy = [Config[:hierarchy]].flatten
+        else
+          hierarchy = ["common"]
+        end
+
+        hierarchy.insert(0, override) if override
+
+        hierarchy.flatten.map do |source|
+          source = parse_string(source, scope)
+          yield(source) unless source == "" or source =~ /(^\/|\/\/|\/$)/
+        end
+      end
+
+      # Parse a string like '%{foo}' against a supplied
+      # scope and additional scope.  If either scope or
+      # extra_scope includes the varaible 'foo' it will
+      # be replaced else an empty string will be placed.
+      #
+      # If both scope and extra_data has "foo" scope
+      # will win.  See hiera-puppet for an example of
+      # this to make hiera aware of additional non scope
+      # variables
+      def parse_string(data, scope, extra_data={})
+        return nil unless data
+
+        tdata = data.clone
+
+        if tdata.is_a?(String)
+          while tdata =~ /%\{(.+?)\}/
+            var = $1
+            val = scope[var] || extra_data[var] || ""
+
+            # Puppet can return this for unknown scope vars
+            val = "" if val == :undefined
+
+            tdata.gsub!(/%\{#{var}\}/, val)
+          end
+        end
+
+        return tdata
+      end
+
+      # Parses a answer received from data files
+      #
+      # Ultimately it just pass the data through parse_string but
+      # it makes some effort to handle arrays of strings as well
+      def parse_answer(data, scope, extra_data={})
+        if data.is_a?(Numeric) or data.is_a?(TrueClass) or data.is_a?(FalseClass)
+          return data
+        elsif data.is_a?(String)
+          return parse_string(data, scope, extra_data)
+        elsif data.is_a?(Hash)
+          answer = {}
+          data.each_pair do |key, val|
+            answer[key] = parse_answer(val, scope, extra_data)
+          end
+
+          return answer
+        elsif data.is_a?(Array)
+          answer = []
+          data.each do |item|
+            answer << parse_answer(item, scope, extra_data)
+          end
+
+          return answer
+        end
+      end
+
+      def resolve_answer(answer, resolution_type)
+        case resolution_type
+        when :array
+          [answer].flatten.uniq.compact
+        when :hash
+          answer # Hash structure should be preserved
+        else
+          answer
+        end
+      end
+
+      # Calls out to all configured backends in the order they
+      # were specified.  The first one to answer will win.
+      #
+      # This lets you declare multiple backends, a possible
+      # use case might be in Puppet where a Puppet module declares
+      # default data using in-module data while users can override
+      # using JSON/YAML etc.  By layering the backends and putting
+      # the Puppet one last you can override module author data
+      # easily.
+      #
+      # Backend instances are cached so if you need to connect to any
+      # databases then do so in your constructor, future calls to your
+      # backend will not create new instances
+      def lookup(key, default, scope, order_override, resolution_type)
+        @backends ||= {}
+        answer = nil
+
+        Config[:backends].each do |backend|
+          if constants.include?("#{backend.capitalize}_backend")
+            @backends[backend] ||= Backend.const_get("#{backend.capitalize}_backend").new
+            answer = @backends[backend].lookup(key, scope, order_override, resolution_type)
+
+            break if answer
+          end
+        end
+
+        answer = resolve_answer(answer, resolution_type)
+        answer = parse_string(default, scope) if answer.nil?
+
+        return default if answer == empty_answer(resolution_type)
+        return answer
+      end
     end
+  end
 end

--- a/lib/hiera/backend/yaml_backend.rb
+++ b/lib/hiera/backend/yaml_backend.rb
@@ -1,49 +1,49 @@
 class Hiera
-    module Backend
-        class Yaml_backend
-            def initialize
-                require 'yaml'
+  module Backend
+    class Yaml_backend
+      def initialize
+        require 'yaml'
 
-                Hiera.debug("Hiera YAML backend starting")
-            end
+        Hiera.debug("Hiera YAML backend starting")
+      end
 
-            def lookup(key, scope, order_override, resolution_type)
-                answer = Backend.empty_answer(resolution_type)
+      def lookup(key, scope, order_override, resolution_type)
+        answer = Backend.empty_answer(resolution_type)
 
-                Hiera.debug("Looking up #{key} in YAML backend")
+        Hiera.debug("Looking up #{key} in YAML backend")
 
-                Backend.datasources(scope, order_override) do |source|
-                    Hiera.debug("Looking for data source #{source}")
+        Backend.datasources(scope, order_override) do |source|
+          Hiera.debug("Looking for data source #{source}")
 
-                    yamlfile = Backend.datafile(:yaml, scope, source, "yaml") || next
+          yamlfile = Backend.datafile(:yaml, scope, source, "yaml") || next
 
-                    data = YAML.load_file(yamlfile)
+          data = YAML.load_file(yamlfile)
 
-                    next if ! data
-                    next if data.empty?
-                    next unless data.include?(key)
+          next if ! data
+          next if data.empty?
+          next unless data.include?(key)
 
-                    # for array resolution we just append to the array whatever
-                    # we find, we then goes onto the next file and keep adding to
-                    # the array
-                    #
-                    # for priority searches we break after the first found data item
-                    new_answer = Backend.parse_answer(data[key], scope)
-                    case resolution_type
-                    when :array
-                        raise Exception, "Hiera type mismatch: expected Array and got #{new_answer.class}" unless new_answer.kind_of? Array or new_answer.kind_of? String
-                        answer << new_answer
-                    when :hash
-                        raise Exception, "Hiera type mismatch: expected Hash and got #{new_answer.class}" unless new_answer.kind_of? Hash
-                        answer = new_answer.merge answer
-                    else
-                        answer = new_answer
-                        break
-                    end
-                end
-
-                return answer
-            end
+          # for array resolution we just append to the array whatever
+          # we find, we then goes onto the next file and keep adding to
+          # the array
+          #
+          # for priority searches we break after the first found data item
+          new_answer = Backend.parse_answer(data[key], scope)
+          case resolution_type
+          when :array
+            raise Exception, "Hiera type mismatch: expected Array and got #{new_answer.class}" unless new_answer.kind_of? Array or new_answer.kind_of? String
+            answer << new_answer
+          when :hash
+            raise Exception, "Hiera type mismatch: expected Hash and got #{new_answer.class}" unless new_answer.kind_of? Hash
+            answer = new_answer.merge answer
+          else
+            answer = new_answer
+            break
+          end
         end
+
+        return answer
+      end
     end
+  end
 end

--- a/lib/hiera/config.rb
+++ b/lib/hiera/config.rb
@@ -1,51 +1,51 @@
 class Hiera::Config
-    class << self
-        # Takes a string or hash as input, strings are treated as filenames
-        # hashes are stored as data that would have been in the config file
-        #
-        # Unless specified it will only use YAML as backend with a single
-        # 'common' hierarchy and console logger
-        def load(source)
-            @config = {:backends => "yaml",
-                       :hierarchy => "common"}
+  class << self
+    # Takes a string or hash as input, strings are treated as filenames
+    # hashes are stored as data that would have been in the config file
+    #
+    # Unless specified it will only use YAML as backend with a single
+    # 'common' hierarchy and console logger
+    def load(source)
+      @config = {:backends => "yaml",
+                 :hierarchy => "common"}
 
-            if source.is_a?(String)
-                raise "Config file #{source} not found" unless File.exist?(source)
+      if source.is_a?(String)
+        raise "Config file #{source} not found" unless File.exist?(source)
 
-                config = YAML.load_file(source)
-                @config.merge! config if config
-            elsif source.is_a?(Hash)
-                @config.merge! source
-            end
+        config = YAML.load_file(source)
+        @config.merge! config if config
+      elsif source.is_a?(Hash)
+        @config.merge! source
+      end
 
-            @config[:backends] = [ @config[:backends] ].flatten
+      @config[:backends] = [ @config[:backends] ].flatten
 
-            if @config.include?(:logger)
-                Hiera.logger = @config[:logger].to_s
-            else
-                @config[:logger] = "console"
-                Hiera.logger = "console"
-            end
+      if @config.include?(:logger)
+        Hiera.logger = @config[:logger].to_s
+      else
+        @config[:logger] = "console"
+        Hiera.logger = "console"
+      end
 
-            @config
-        end
-
-        def load_backends
-            @config[:backends].each do |backend|
-                begin
-                    require "hiera/backend/#{backend.downcase}_backend"
-                rescue LoadError => e
-                    Hiera.warn "Cannot load backend #{backend}: #{e}"
-                end
-            end
-        end
-
-        def include?(key)
-            @config.include?(key)
-        end
-
-        def [](key)
-            @config[key]
-        end
+      @config
     end
+
+    def load_backends
+      @config[:backends].each do |backend|
+        begin
+          require "hiera/backend/#{backend.downcase}_backend"
+        rescue LoadError => e
+          Hiera.warn "Cannot load backend #{backend}: #{e}"
+        end
+      end
+    end
+
+    def include?(key)
+      @config.include?(key)
+    end
+
+    def [](key)
+      @config[key]
+    end
+  end
 end

--- a/lib/hiera/console_logger.rb
+++ b/lib/hiera/console_logger.rb
@@ -1,13 +1,13 @@
 class Hiera
-    module Console_logger
-        class << self
-            def warn(msg)
-                STDERR.puts("WARN: %s: %s" % [Time.now.to_s, msg])
-            end
+  module Console_logger
+    class << self
+      def warn(msg)
+        STDERR.puts("WARN: %s: %s" % [Time.now.to_s, msg])
+      end
 
-            def debug(msg)
-                STDERR.puts("DEBUG: %s: %s" % [Time.now.to_s, msg])
-            end
-        end
+      def debug(msg)
+        STDERR.puts("DEBUG: %s: %s" % [Time.now.to_s, msg])
+      end
     end
+  end
 end

--- a/lib/hiera/puppet_logger.rb
+++ b/lib/hiera/puppet_logger.rb
@@ -1,8 +1,8 @@
 class Hiera
-    module Puppet_logger
-        class << self
-            def warn(msg); Puppet.notice("hiera(): #{msg}"); end
-            def debug(msg); Puppet.debug("hiera(): #{msg}"); end
-        end
+  module Puppet_logger
+    class << self
+      def warn(msg); Puppet.notice("hiera(): #{msg}"); end
+      def debug(msg); Puppet.debug("hiera(): #{msg}"); end
     end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,13 +7,13 @@ require 'rspec/mocks'
 require 'mocha'
 
 RSpec.configure do |config|
-    config.mock_with :mocha
+  config.mock_with :mocha
 end
 
 class Puppet
-    class Parser
-        class Functions
-        end
+  class Parser
+    class Functions
     end
+  end
 end
 

--- a/spec/unit/backend/yaml_backend_spec.rb
+++ b/spec/unit/backend/yaml_backend_spec.rb
@@ -3,138 +3,138 @@ require 'spec_helper'
 require 'hiera/backend/yaml_backend'
 
 class Hiera
-    module Backend
-        describe Yaml_backend do
-            before do
-                Hiera.stubs(:debug)
-                Hiera.stubs(:warn)
-                @backend = Yaml_backend.new
-            end
+  module Backend
+    describe Yaml_backend do
+      before do
+        Hiera.stubs(:debug)
+        Hiera.stubs(:warn)
+        @backend = Yaml_backend.new
+      end
 
-            describe "#initialize" do
-                it "should announce its creation" do # because other specs checks this
-                    Hiera.expects(:debug).with("Hiera YAML backend starting")
-                    Yaml_backend.new
-                end
-            end
-
-            describe "#lookup" do
-                it "should look for data in all sources" do
-                    Backend.expects(:datasources).multiple_yields(["one"], ["two"])
-                    Backend.expects(:datafile).with(:yaml, {}, "one", "yaml").returns(nil)
-                    Backend.expects(:datafile).with(:yaml, {}, "two", "yaml").returns(nil)
-
-                    @backend.lookup("key", {}, nil, :priority)
-                end
-
-                it "should pick data earliest source that has it for priority searches" do
-                    Backend.expects(:datasources).multiple_yields(["one"], ["two"])
-                    Backend.expects(:datafile).with(:yaml, {}, "one", "yaml").returns("/nonexisting/one.yaml")
-                    Backend.expects(:datafile).with(:yaml, {}, "two", "yaml").returns(nil).never
-                    YAML.expects(:load_file).with("/nonexisting/one.yaml").returns(YAML.load("---\nkey: answer"))
-
-                    @backend.lookup("key", {}, nil, :priority).should == "answer"
-                end
-
-                it "should not look up missing data files" do
-                    Backend.expects(:datasources).multiple_yields(["one"])
-                    Backend.expects(:datafile).with(:yaml, {}, "one", "yaml").returns(nil)
-                    YAML.expects(:load_file).never
-
-                    @backend.lookup("key", {}, nil, :priority)
-                end
-
-                it "should return nil for empty data files" do
-                    Backend.expects(:datasources).multiple_yields(["one"])
-                    Backend.expects(:datafile).with(:yaml, {}, "one", "yaml").returns("/nonexisting/one.yaml")
-                    YAML.expects(:load_file).with("/nonexisting/one.yaml").returns(YAML.load(""))
-
-                    @backend.lookup("key", {}, nil, :priority).should be_nil
-                end
-
-                it "should build an array of all data sources for array searches" do
-                    Backend.expects(:datasources).multiple_yields(["one"], ["two"])
-                    Backend.expects(:datafile).with(:yaml, {}, "one", "yaml").returns("/nonexisting/one.yaml")
-                    Backend.expects(:datafile).with(:yaml, {}, "two", "yaml").returns("/nonexisting/two.yaml")
-
-                    YAML.expects(:load_file).with("/nonexisting/one.yaml").returns(YAML.load("---\nkey: answer"))
-                    YAML.expects(:load_file).with("/nonexisting/two.yaml").returns(YAML.load("---\nkey: answer"))
-
-                    @backend.lookup("key", {}, nil, :array).should == ["answer", "answer"]
-                end
-
-                it "should return empty hash of data sources for hash searches" do
-                    Backend.expects(:datasources).multiple_yields(["one"])
-                    Backend.expects(:datafile).with(:yaml, {}, "one", "yaml").returns("/nonexisting/one.yaml")
-
-                    YAML.expects(:load_file).with("/nonexisting/one.yaml").returns(YAML.load(""))
-
-                    @backend.lookup("key", {}, nil, :hash).should == {}
-                end
-
-                it "should ignore empty hash of data sources for hash searches" do
-                    Backend.expects(:datasources).multiple_yields(["one"], ["two"])
-                    Backend.expects(:datafile).with(:yaml, {}, "one", "yaml").returns("/nonexisting/one.yaml")
-                    Backend.expects(:datafile).with(:yaml, {}, "two", "yaml").returns("/nonexisting/two.yaml")
-
-                    YAML.expects(:load_file).with("/nonexisting/one.yaml").returns(YAML.load(""))
-                    YAML.expects(:load_file).with("/nonexisting/two.yaml").returns(YAML.load("---\nkey:\n a: answer"))
-
-                    @backend.lookup("key", {}, nil, :hash).should == {"a" => "answer"}
-                end
-
-                it "should build a merged hash of data sources for hash searches" do
-                    Backend.expects(:datasources).multiple_yields(["one"], ["two"])
-                    Backend.expects(:datafile).with(:yaml, {}, "one", "yaml").returns("/nonexisting/one.yaml")
-                    Backend.expects(:datafile).with(:yaml, {}, "two", "yaml").returns("/nonexisting/two.yaml")
-
-                    YAML.expects(:load_file).with("/nonexisting/one.yaml").returns(YAML.load("---\nkey:\n a: answer"))
-                    YAML.expects(:load_file).with("/nonexisting/two.yaml").returns(YAML.load("---\nkey:\n a: wrong\n b: answer"))
-
-                    @backend.lookup("key", {}, nil, :hash).should == {"a" => "answer", "b" => "answer"}
-                end
-
-                it "should fail when trying to << a Hash" do
-                    Backend.expects(:datasources).multiple_yields(["one"], ["two"])
-                    Backend.expects(:datafile).with(:yaml, {}, "one", "yaml").returns("/nonexisting/one.yaml")
-                    Backend.expects(:datafile).with(:yaml, {}, "two", "yaml").returns("/nonexisting/two.yaml")
-
-                    YAML.expects(:load_file).with("/nonexisting/one.yaml").returns(YAML.load("---\nkey:\n- a\n- answer"))
-                    YAML.expects(:load_file).with("/nonexisting/two.yaml").returns(YAML.load("---\nkey:\n a: answer"))
-
-                    lambda {@backend.lookup("key", {}, nil, :array)}.should raise_error(Exception, "Hiera type mismatch: expected Array and got Hash")
-                end
-
-                it "should fail when trying to merge an Array" do
-                    Backend.expects(:datasources).multiple_yields(["one"], ["two"])
-                    Backend.expects(:datafile).with(:yaml, {}, "one", "yaml").returns("/nonexisting/one.yaml")
-                    Backend.expects(:datafile).with(:yaml, {}, "two", "yaml").returns("/nonexisting/two.yaml")
-
-                    YAML.expects(:load_file).with("/nonexisting/one.yaml").returns(YAML.load("---\nkey:\n a: answer"))
-                    YAML.expects(:load_file).with("/nonexisting/two.yaml").returns(YAML.load("---\nkey:\n- a\n- wrong"))
-
-                    lambda {@backend.lookup("key", {}, nil, :hash)}.should raise_error(Exception, "Hiera type mismatch: expected Hash and got Array")
-                end
-
-                it "should parse the answer for scope variables" do
-                    Backend.expects(:datasources).yields("one")
-                    Backend.expects(:datafile).with(:yaml, {"rspec" => "test"}, "one", "yaml").returns("/nonexisting/one.yaml")
-                    YAML.expects(:load_file).with("/nonexisting/one.yaml").returns(YAML.load("---\nkey: 'test_%{rspec}'"))
-
-                    @backend.lookup("key", {"rspec" => "test"}, nil, :priority).should == "test_test"
-                end
-
-                it "should retain datatypes found in yaml files" do
-                    Backend.expects(:datasources).yields("one").times(3)
-                    Backend.expects(:datafile).with(:yaml, {}, "one", "yaml").returns("/nonexisting/one.yaml").times(3)
-
-                    YAML.expects(:load_file).with("/nonexisting/one.yaml").returns(YAML.load("---\nstringval: 'string'\nboolval: true\nnumericval: 1")).times(3)
-
-                    @backend.lookup("stringval", {}, nil, :priority).should == "string"
-                    @backend.lookup("boolval", {}, nil, :priority).should == true
-                    @backend.lookup("numericval", {}, nil, :priority).should == 1
-                end
-            end
+      describe "#initialize" do
+        it "should announce its creation" do # because other specs checks this
+          Hiera.expects(:debug).with("Hiera YAML backend starting")
+          Yaml_backend.new
         end
+      end
+
+      describe "#lookup" do
+        it "should look for data in all sources" do
+          Backend.expects(:datasources).multiple_yields(["one"], ["two"])
+          Backend.expects(:datafile).with(:yaml, {}, "one", "yaml").returns(nil)
+          Backend.expects(:datafile).with(:yaml, {}, "two", "yaml").returns(nil)
+
+          @backend.lookup("key", {}, nil, :priority)
+        end
+
+        it "should pick data earliest source that has it for priority searches" do
+          Backend.expects(:datasources).multiple_yields(["one"], ["two"])
+          Backend.expects(:datafile).with(:yaml, {}, "one", "yaml").returns("/nonexisting/one.yaml")
+          Backend.expects(:datafile).with(:yaml, {}, "two", "yaml").returns(nil).never
+          YAML.expects(:load_file).with("/nonexisting/one.yaml").returns(YAML.load("---\nkey: answer"))
+
+          @backend.lookup("key", {}, nil, :priority).should == "answer"
+        end
+
+        it "should not look up missing data files" do
+          Backend.expects(:datasources).multiple_yields(["one"])
+          Backend.expects(:datafile).with(:yaml, {}, "one", "yaml").returns(nil)
+          YAML.expects(:load_file).never
+
+          @backend.lookup("key", {}, nil, :priority)
+        end
+
+        it "should return nil for empty data files" do
+          Backend.expects(:datasources).multiple_yields(["one"])
+          Backend.expects(:datafile).with(:yaml, {}, "one", "yaml").returns("/nonexisting/one.yaml")
+          YAML.expects(:load_file).with("/nonexisting/one.yaml").returns(YAML.load(""))
+
+          @backend.lookup("key", {}, nil, :priority).should be_nil
+        end
+
+        it "should build an array of all data sources for array searches" do
+          Backend.expects(:datasources).multiple_yields(["one"], ["two"])
+          Backend.expects(:datafile).with(:yaml, {}, "one", "yaml").returns("/nonexisting/one.yaml")
+          Backend.expects(:datafile).with(:yaml, {}, "two", "yaml").returns("/nonexisting/two.yaml")
+
+          YAML.expects(:load_file).with("/nonexisting/one.yaml").returns(YAML.load("---\nkey: answer"))
+          YAML.expects(:load_file).with("/nonexisting/two.yaml").returns(YAML.load("---\nkey: answer"))
+
+          @backend.lookup("key", {}, nil, :array).should == ["answer", "answer"]
+        end
+
+        it "should return empty hash of data sources for hash searches" do
+          Backend.expects(:datasources).multiple_yields(["one"])
+          Backend.expects(:datafile).with(:yaml, {}, "one", "yaml").returns("/nonexisting/one.yaml")
+
+          YAML.expects(:load_file).with("/nonexisting/one.yaml").returns(YAML.load(""))
+
+          @backend.lookup("key", {}, nil, :hash).should == {}
+        end
+
+        it "should ignore empty hash of data sources for hash searches" do
+          Backend.expects(:datasources).multiple_yields(["one"], ["two"])
+          Backend.expects(:datafile).with(:yaml, {}, "one", "yaml").returns("/nonexisting/one.yaml")
+          Backend.expects(:datafile).with(:yaml, {}, "two", "yaml").returns("/nonexisting/two.yaml")
+
+          YAML.expects(:load_file).with("/nonexisting/one.yaml").returns(YAML.load(""))
+          YAML.expects(:load_file).with("/nonexisting/two.yaml").returns(YAML.load("---\nkey:\n a: answer"))
+
+          @backend.lookup("key", {}, nil, :hash).should == {"a" => "answer"}
+        end
+
+        it "should build a merged hash of data sources for hash searches" do
+          Backend.expects(:datasources).multiple_yields(["one"], ["two"])
+          Backend.expects(:datafile).with(:yaml, {}, "one", "yaml").returns("/nonexisting/one.yaml")
+          Backend.expects(:datafile).with(:yaml, {}, "two", "yaml").returns("/nonexisting/two.yaml")
+
+          YAML.expects(:load_file).with("/nonexisting/one.yaml").returns(YAML.load("---\nkey:\n a: answer"))
+          YAML.expects(:load_file).with("/nonexisting/two.yaml").returns(YAML.load("---\nkey:\n a: wrong\n b: answer"))
+
+          @backend.lookup("key", {}, nil, :hash).should == {"a" => "answer", "b" => "answer"}
+        end
+
+        it "should fail when trying to << a Hash" do
+          Backend.expects(:datasources).multiple_yields(["one"], ["two"])
+          Backend.expects(:datafile).with(:yaml, {}, "one", "yaml").returns("/nonexisting/one.yaml")
+          Backend.expects(:datafile).with(:yaml, {}, "two", "yaml").returns("/nonexisting/two.yaml")
+
+          YAML.expects(:load_file).with("/nonexisting/one.yaml").returns(YAML.load("---\nkey:\n- a\n- answer"))
+          YAML.expects(:load_file).with("/nonexisting/two.yaml").returns(YAML.load("---\nkey:\n a: answer"))
+
+          lambda {@backend.lookup("key", {}, nil, :array)}.should raise_error(Exception, "Hiera type mismatch: expected Array and got Hash")
+        end
+
+        it "should fail when trying to merge an Array" do
+          Backend.expects(:datasources).multiple_yields(["one"], ["two"])
+          Backend.expects(:datafile).with(:yaml, {}, "one", "yaml").returns("/nonexisting/one.yaml")
+          Backend.expects(:datafile).with(:yaml, {}, "two", "yaml").returns("/nonexisting/two.yaml")
+
+          YAML.expects(:load_file).with("/nonexisting/one.yaml").returns(YAML.load("---\nkey:\n a: answer"))
+          YAML.expects(:load_file).with("/nonexisting/two.yaml").returns(YAML.load("---\nkey:\n- a\n- wrong"))
+
+          lambda {@backend.lookup("key", {}, nil, :hash)}.should raise_error(Exception, "Hiera type mismatch: expected Hash and got Array")
+        end
+
+        it "should parse the answer for scope variables" do
+          Backend.expects(:datasources).yields("one")
+          Backend.expects(:datafile).with(:yaml, {"rspec" => "test"}, "one", "yaml").returns("/nonexisting/one.yaml")
+          YAML.expects(:load_file).with("/nonexisting/one.yaml").returns(YAML.load("---\nkey: 'test_%{rspec}'"))
+
+          @backend.lookup("key", {"rspec" => "test"}, nil, :priority).should == "test_test"
+        end
+
+        it "should retain datatypes found in yaml files" do
+          Backend.expects(:datasources).yields("one").times(3)
+          Backend.expects(:datafile).with(:yaml, {}, "one", "yaml").returns("/nonexisting/one.yaml").times(3)
+
+          YAML.expects(:load_file).with("/nonexisting/one.yaml").returns(YAML.load("---\nstringval: 'string'\nboolval: true\nnumericval: 1")).times(3)
+
+          @backend.lookup("stringval", {}, nil, :priority).should == "string"
+          @backend.lookup("boolval", {}, nil, :priority).should == true
+          @backend.lookup("numericval", {}, nil, :priority).should == 1
+        end
+      end
     end
+  end
 end

--- a/spec/unit/backend_spec.rb
+++ b/spec/unit/backend_spec.rb
@@ -1,283 +1,282 @@
 require 'spec_helper'
 
 class Hiera
-    describe Backend do
-        describe "#datadir" do
-            it "should use the backend configured dir" do
-                Config.load({:rspec => {:datadir => "/tmp"}})
-                Backend.expects(:parse_string).with("/tmp", {})
-                Backend.datadir(:rspec, {})
-            end
+  describe Backend do
+    describe "#datadir" do
+      it "should use the backend configured dir" do
+        Config.load({:rspec => {:datadir => "/tmp"}})
+        Backend.expects(:parse_string).with("/tmp", {})
+        Backend.datadir(:rspec, {})
+      end
 
-            it "should default to /var/lib/hiera" do
-                Config.load({})
-                Backend.expects(:parse_string).with("/var/lib/hiera", {})
-                Backend.datadir(:rspec, {})
-            end
-        end
-
-        describe "#empty_anwer" do
-            it "should return [] for array searches" do
-                Backend.empty_answer(:array).should == []
-            end
-
-            it "should return {} for hash searches" do
-                Backend.empty_answer(:hash).should == {}
-            end
-
-            it "should return nil otherwise" do
-                Backend.empty_answer(:meh).should == nil
-            end
-        end
-
-        describe "#datafile" do
-            it "should check if the file exist and return nil if not" do
-                Hiera.expects(:debug).with("Cannot find datafile /nonexisting/test.yaml, skipping")
-                Backend.expects(:datadir).returns("/nonexisting")
-                Backend.datafile(:yaml, {}, "test", "yaml").should == nil
-            end
-
-            it "should return the correct file name" do
-                Backend.expects(:datadir).returns("/nonexisting")
-                File.expects(:exist?).with("/nonexisting/test.yaml").returns(true)
-                Backend.datafile(:yaml, {}, "test", "yaml").should == "/nonexisting/test.yaml"
-            end
-        end
-
-        describe "#datasources" do
-            it "should use the supplied hierarchy" do
-                expected = ["one", "two"]
-                Backend.datasources({}, nil, ["one", "two"]) do |backend|
-                    backend.should == expected.delete_at(0)
-                end
-
-                expected.empty?.should == true
-            end
-
-            it "should use the configured hierarchy if none is supplied" do
-                Config.load(:hierarchy => "test")
-
-                Backend.datasources({}) do |backend|
-                    backend.should == "test"
-                end
-            end
-
-            it "should default to common if not configured or supplied" do
-                Config.load({})
-
-                Backend.datasources({}) do |backend|
-                    backend.should == "common"
-                end
-            end
-
-            it "should insert the override if provided" do
-                Config.load({})
-
-                expected = ["override", "common"]
-                Backend.datasources({}, "override") do |backend|
-                    backend.should == expected.delete_at(0)
-                end
-
-                expected.empty?.should == true
-            end
-
-            it "should parse the sources based on scope" do
-                Backend.expects(:parse_string).with("common", {:rspec => :tests})
-                Backend.datasources({:rspec => :tests}) { }
-            end
-
-            it "should not return empty sources" do
-                Config.load({})
-
-                expected = ["common"]
-                Backend.datasources({}, "%{rspec}") do |backend|
-                    backend.should == expected.delete_at(0)
-                end
-
-                expected.empty?.should == true
-            end
-        end
-
-        describe "#parse_string" do
-            it "should not try to parse invalid data" do
-                Backend.parse_string(nil, {}).should == nil
-            end
-
-            it "should clone the supplied data" do
-                data = ""
-                data.expects(:clone).returns("")
-                Backend.parse_string(data, {})
-            end
-
-            it "should only parse string data" do
-                data = ""
-                data.expects(:is_a?).with(String)
-                Backend.parse_string(data, {})
-            end
-
-            it "should match data from scope" do
-                input = "test_%{rspec}_test"
-                Backend.parse_string(input, {"rspec" => "test"}).should == "test_test_test"
-            end
-
-            it "should match data from extra_data" do
-                input = "test_%{rspec}_test"
-                Backend.parse_string(input, {}, {"rspec" => "test"}).should == "test_test_test"
-            end
-
-            it "should prefer scope over extra_data" do
-                input = "test_%{rspec}_test"
-                Backend.parse_string(input, {"rspec" => "test"}, {"rspec" => "fail"}).should == "test_test_test"
-            end
-
-            it "should treat :undefined in scope as empty" do
-                input = "test_%{rspec}_test"
-                Backend.parse_string(input, {"rspec" => :undefined}).should == "test__test"
-            end
-        end
-
-        describe "#parse_answer" do
-            it "should parse strings correctly" do
-                input = "test_%{rspec}_test"
-                Backend.parse_answer(input, {"rspec" => "test"}).should == "test_test_test"
-            end
-
-            it "should parse each string in an array" do
-                input = ["test_%{rspec}_test", "test_%{rspec}_test", ["test_%{rspec}_test"]]
-                Backend.parse_answer(input, {"rspec" => "test"}).should == ["test_test_test", "test_test_test", ["test_test_test"]]
-            end
-
-            it "should parse each string in a hash" do
-                input = {"foo" => "test_%{rspec}_test", "bar" => "test_%{rspec}_test"}
-                Backend.parse_answer(input, {"rspec" => "test"}).should == {"foo"=>"test_test_test", "bar"=>"test_test_test"}
-            end
-
-            it "should parse mixed arrays and hashes" do
-                input = {"foo" => "test_%{rspec}_test", "bar" => ["test_%{rspec}_test", "test_%{rspec}_test"]}
-                Backend.parse_answer(input, {"rspec" => "test"}).should == {"foo"=>"test_test_test", "bar"=>["test_test_test", "test_test_test"]}
-            end
-
-            it "should parse integers correctly" do
-              input = 1
-              Backend.parse_answer(input, {"rspec" => "test"}).should == 1
-            end
-
-            it "should parse floats correctly" do
-              input = 0.233
-              Backend.parse_answer(input, {"rspec" => "test"}).should == 0.233
-            end
-
-            it "should parse true boolean values correctly" do
-              input = true
-              Backend.parse_answer(input, {"rspec" => "test"}).should == true
-            end
-
-            it "should parse false boolean values correctly" do
-              input = false
-              Backend.parse_answer(input, {"rspec" => "test"}).should == false
-            end
-        end
-
-        describe "#resolve_answer" do
-            it "should correctly parse array data" do
-                Backend.resolve_answer(["foo", ["foo", "foo"], "bar"], :array).should == ["foo", "bar"]
-            end
-
-            it "should just return the answer for non array data" do
-                Backend.resolve_answer(["foo", ["foo", "foo"], "bar"], :priority).should == ["foo", ["foo", "foo"], "bar"]
-            end
-        end
-
-        describe "#lookup" do
-            before do
-                Hiera.stubs(:debug)
-                Hiera.stubs(:warn)
-            end
-
-            it "should cache backends" do
-                Hiera.expects(:debug).with(regexp_matches(/Hiera YAML backend starting/)).once
-
-                Config.load({:yaml => {:datadir => "/tmp"}})
-                Config.load_backends
-
-                Backend.lookup("key", "default", {}, nil, nil)
-                Backend.lookup("key", "default", {}, nil, nil)
-            end
-
-            it "should return the answer from the backend" do
-                Config.load({:yaml => {:datadir => "/tmp"}})
-                Config.load_backends
-
-                Backend::Yaml_backend.any_instance.expects(:lookup).with("key", {}, nil, nil).returns("answer")
-
-                Backend.lookup("key", "default", {}, nil, nil).should == "answer"
-            end
-
-            it "should retain the datatypes as returned by the backend" do
-                Config.load({:yaml => {:datadir => "/tmp"}})
-                Config.load_backends
-
-                Backend::Yaml_backend.any_instance.expects(:lookup).with("stringval", {}, nil, nil).returns("string")
-                Backend::Yaml_backend.any_instance.expects(:lookup).with("boolval", {}, nil, nil).returns(false)
-                Backend::Yaml_backend.any_instance.expects(:lookup).with("numericval", {}, nil, nil).returns(1)
-
-                Backend.lookup("stringval", "default", {}, nil, nil).should == "string"
-                Backend.lookup("boolval", "default", {}, nil, nil).should == false
-                Backend.lookup("numericval", "default", {}, nil, nil).should == 1
-            end
-
-            it "should call to all backends till an answer is found" do
-                backend = mock
-                backend.expects(:lookup).returns("answer")
-                Config.load({})
-                Config.instance_variable_set("@config", {:backends => ["yaml", "rspec"]})
-                Backend.instance_variable_set("@backends", {"rspec" => backend})
-                Backend::Yaml_backend.any_instance.expects(:lookup).with("key", {"rspec" => "test"}, nil, nil)
-                Backend.expects(:constants).returns(["Yaml_backend", "Rspec_backend"]).twice
-
-                Backend.lookup("key", "test_%{rspec}", {"rspec" => "test"}, nil, nil).should == "answer"
-
-            end
-
-            it "should parse the answers based on resolution_type" do
-                Config.load({:yaml => {:datadir => "/tmp"}})
-                Config.load_backends
-
-                Backend.expects(:resolve_answer).with("test_test", :priority).returns("parsed")
-                Backend::Yaml_backend.any_instance.expects(:lookup).with("key", {"rspec" => "test"}, nil, :priority).returns("test_test")
-
-                Backend.lookup("key", "test_%{rspec}", {"rspec" => "test"}, nil, :priority).should == "parsed"
-            end
-
-            it "should return the default with variables parsed if nothing is found" do
-                Config.load({:yaml => {:datadir => "/tmp"}})
-                Config.load_backends
-
-                Backend::Yaml_backend.any_instance.expects(:lookup).with("key", {"rspec" => "test"}, nil, nil)
-
-                Backend.lookup("key", "test_%{rspec}", {"rspec" => "test"}, nil, nil).should == "test_test"
-            end
-
-            it "should correctly handle string default data" do
-                Config.load({:yaml => {:datadir => "/tmp"}})
-                Config.load_backends
-                Backend::Yaml_backend.any_instance.expects(:lookup).with("key", {}, nil, nil)
-                Backend.lookup("key", "test", {}, nil, nil).should == "test"
-            end
-
-            it "should correctly handle array default data" do
-                Config.load({:yaml => {:datadir => "/tmp"}})
-                Config.load_backends
-                Backend::Yaml_backend.any_instance.expects(:lookup).with("key", {}, nil, :array)
-                Backend.lookup("key", ["test"], {}, nil, :array).should == ["test"]
-            end
-
-            it "should correctly handle hash default data" do
-                Config.load({:yaml => {:datadir => "/tmp"}})
-                Config.load_backends
-                Backend::Yaml_backend.any_instance.expects(:lookup).with("key", {}, nil, :hash)
-                Backend.lookup("key", {"test" => "value"}, {}, nil, :hash).should == {"test" => "value"}
-            end
-        end
+      it "should default to /var/lib/hiera" do
+        Config.load({})
+        Backend.expects(:parse_string).with("/var/lib/hiera", {})
+        Backend.datadir(:rspec, {})
+      end
     end
+
+    describe "#empty_anwer" do
+      it "should return [] for array searches" do
+        Backend.empty_answer(:array).should == []
+      end
+
+      it "should return {} for hash searches" do
+        Backend.empty_answer(:hash).should == {}
+      end
+
+      it "should return nil otherwise" do
+        Backend.empty_answer(:meh).should == nil
+      end
+    end
+
+    describe "#datafile" do
+      it "should check if the file exist and return nil if not" do
+        Hiera.expects(:debug).with("Cannot find datafile /nonexisting/test.yaml, skipping")
+        Backend.expects(:datadir).returns("/nonexisting")
+        Backend.datafile(:yaml, {}, "test", "yaml").should == nil
+      end
+
+      it "should return the correct file name" do
+        Backend.expects(:datadir).returns("/nonexisting")
+        File.expects(:exist?).with("/nonexisting/test.yaml").returns(true)
+        Backend.datafile(:yaml, {}, "test", "yaml").should == "/nonexisting/test.yaml"
+      end
+    end
+
+    describe "#datasources" do
+      it "should use the supplied hierarchy" do
+        expected = ["one", "two"]
+        Backend.datasources({}, nil, ["one", "two"]) do |backend|
+          backend.should == expected.delete_at(0)
+        end
+
+        expected.empty?.should == true
+      end
+
+      it "should use the configured hierarchy if none is supplied" do
+        Config.load(:hierarchy => "test")
+
+        Backend.datasources({}) do |backend|
+          backend.should == "test"
+        end
+      end
+
+      it "should default to common if not configured or supplied" do
+        Config.load({})
+
+        Backend.datasources({}) do |backend|
+          backend.should == "common"
+        end
+      end
+
+      it "should insert the override if provided" do
+        Config.load({})
+
+        expected = ["override", "common"]
+        Backend.datasources({}, "override") do |backend|
+          backend.should == expected.delete_at(0)
+        end
+
+        expected.empty?.should == true
+      end
+
+      it "should parse the sources based on scope" do
+        Backend.expects(:parse_string).with("common", {:rspec => :tests})
+        Backend.datasources({:rspec => :tests}) { }
+      end
+
+      it "should not return empty sources" do
+        Config.load({})
+
+        expected = ["common"]
+        Backend.datasources({}, "%{rspec}") do |backend|
+          backend.should == expected.delete_at(0)
+        end
+
+        expected.empty?.should == true
+      end
+    end
+
+    describe "#parse_string" do
+      it "should not try to parse invalid data" do
+        Backend.parse_string(nil, {}).should == nil
+      end
+
+      it "should clone the supplied data" do
+        data = ""
+        data.expects(:clone).returns("")
+        Backend.parse_string(data, {})
+      end
+
+      it "should only parse string data" do
+        data = ""
+        data.expects(:is_a?).with(String)
+        Backend.parse_string(data, {})
+      end
+
+      it "should match data from scope" do
+        input = "test_%{rspec}_test"
+        Backend.parse_string(input, {"rspec" => "test"}).should == "test_test_test"
+      end
+
+      it "should match data from extra_data" do
+        input = "test_%{rspec}_test"
+        Backend.parse_string(input, {}, {"rspec" => "test"}).should == "test_test_test"
+      end
+
+      it "should prefer scope over extra_data" do
+        input = "test_%{rspec}_test"
+        Backend.parse_string(input, {"rspec" => "test"}, {"rspec" => "fail"}).should == "test_test_test"
+      end
+
+      it "should treat :undefined in scope as empty" do
+        input = "test_%{rspec}_test"
+        Backend.parse_string(input, {"rspec" => :undefined}).should == "test__test"
+      end
+    end
+
+    describe "#parse_answer" do
+      it "should parse strings correctly" do
+        input = "test_%{rspec}_test"
+        Backend.parse_answer(input, {"rspec" => "test"}).should == "test_test_test"
+      end
+
+      it "should parse each string in an array" do
+        input = ["test_%{rspec}_test", "test_%{rspec}_test", ["test_%{rspec}_test"]]
+        Backend.parse_answer(input, {"rspec" => "test"}).should == ["test_test_test", "test_test_test", ["test_test_test"]]
+      end
+
+      it "should parse each string in a hash" do
+        input = {"foo" => "test_%{rspec}_test", "bar" => "test_%{rspec}_test"}
+        Backend.parse_answer(input, {"rspec" => "test"}).should == {"foo"=>"test_test_test", "bar"=>"test_test_test"}
+      end
+
+      it "should parse mixed arrays and hashes" do
+        input = {"foo" => "test_%{rspec}_test", "bar" => ["test_%{rspec}_test", "test_%{rspec}_test"]}
+        Backend.parse_answer(input, {"rspec" => "test"}).should == {"foo"=>"test_test_test", "bar"=>["test_test_test", "test_test_test"]}
+      end
+
+      it "should parse integers correctly" do
+        input = 1
+        Backend.parse_answer(input, {"rspec" => "test"}).should == 1
+      end
+
+      it "should parse floats correctly" do
+        input = 0.233
+        Backend.parse_answer(input, {"rspec" => "test"}).should == 0.233
+      end
+
+      it "should parse true boolean values correctly" do
+        input = true
+        Backend.parse_answer(input, {"rspec" => "test"}).should == true
+      end
+
+      it "should parse false boolean values correctly" do
+        input = false
+        Backend.parse_answer(input, {"rspec" => "test"}).should == false
+      end
+    end
+
+    describe "#resolve_answer" do
+      it "should correctly parse array data" do
+        Backend.resolve_answer(["foo", ["foo", "foo"], "bar"], :array).should == ["foo", "bar"]
+      end
+
+      it "should just return the answer for non array data" do
+        Backend.resolve_answer(["foo", ["foo", "foo"], "bar"], :priority).should == ["foo", ["foo", "foo"], "bar"]
+      end
+    end
+
+    describe "#lookup" do
+      before do
+        Hiera.stubs(:debug)
+        Hiera.stubs(:warn)
+      end
+
+      it "should cache backends" do
+        Hiera.expects(:debug).with(regexp_matches(/Hiera YAML backend starting/)).once
+
+        Config.load({:yaml => {:datadir => "/tmp"}})
+        Config.load_backends
+
+        Backend.lookup("key", "default", {}, nil, nil)
+        Backend.lookup("key", "default", {}, nil, nil)
+      end
+
+      it "should return the answer from the backend" do
+        Config.load({:yaml => {:datadir => "/tmp"}})
+        Config.load_backends
+
+        Backend::Yaml_backend.any_instance.expects(:lookup).with("key", {}, nil, nil).returns("answer")
+
+        Backend.lookup("key", "default", {}, nil, nil).should == "answer"
+      end
+
+      it "should retain the datatypes as returned by the backend" do
+        Config.load({:yaml => {:datadir => "/tmp"}})
+        Config.load_backends
+
+        Backend::Yaml_backend.any_instance.expects(:lookup).with("stringval", {}, nil, nil).returns("string")
+        Backend::Yaml_backend.any_instance.expects(:lookup).with("boolval", {}, nil, nil).returns(false)
+        Backend::Yaml_backend.any_instance.expects(:lookup).with("numericval", {}, nil, nil).returns(1)
+
+        Backend.lookup("stringval", "default", {}, nil, nil).should == "string"
+        Backend.lookup("boolval", "default", {}, nil, nil).should == false
+        Backend.lookup("numericval", "default", {}, nil, nil).should == 1
+      end
+
+      it "should call to all backends till an answer is found" do
+        backend = mock
+        backend.expects(:lookup).returns("answer")
+        Config.load({})
+        Config.instance_variable_set("@config", {:backends => ["yaml", "rspec"]})
+        Backend.instance_variable_set("@backends", {"rspec" => backend})
+        Backend::Yaml_backend.any_instance.expects(:lookup).with("key", {"rspec" => "test"}, nil, nil)
+        Backend.expects(:constants).returns(["Yaml_backend", "Rspec_backend"]).twice
+
+        Backend.lookup("key", "test_%{rspec}", {"rspec" => "test"}, nil, nil).should == "answer"
+      end
+
+      it "should parse the answers based on resolution_type" do
+        Config.load({:yaml => {:datadir => "/tmp"}})
+        Config.load_backends
+
+        Backend.expects(:resolve_answer).with("test_test", :priority).returns("parsed")
+        Backend::Yaml_backend.any_instance.expects(:lookup).with("key", {"rspec" => "test"}, nil, :priority).returns("test_test")
+
+        Backend.lookup("key", "test_%{rspec}", {"rspec" => "test"}, nil, :priority).should == "parsed"
+      end
+
+      it "should return the default with variables parsed if nothing is found" do
+        Config.load({:yaml => {:datadir => "/tmp"}})
+        Config.load_backends
+
+        Backend::Yaml_backend.any_instance.expects(:lookup).with("key", {"rspec" => "test"}, nil, nil)
+
+        Backend.lookup("key", "test_%{rspec}", {"rspec" => "test"}, nil, nil).should == "test_test"
+      end
+
+      it "should correctly handle string default data" do
+        Config.load({:yaml => {:datadir => "/tmp"}})
+        Config.load_backends
+        Backend::Yaml_backend.any_instance.expects(:lookup).with("key", {}, nil, nil)
+        Backend.lookup("key", "test", {}, nil, nil).should == "test"
+      end
+
+      it "should correctly handle array default data" do
+        Config.load({:yaml => {:datadir => "/tmp"}})
+        Config.load_backends
+        Backend::Yaml_backend.any_instance.expects(:lookup).with("key", {}, nil, :array)
+        Backend.lookup("key", ["test"], {}, nil, :array).should == ["test"]
+      end
+
+      it "should correctly handle hash default data" do
+        Config.load({:yaml => {:datadir => "/tmp"}})
+        Config.load_backends
+        Backend::Yaml_backend.any_instance.expects(:lookup).with("key", {}, nil, :hash)
+        Backend.lookup("key", {"test" => "value"}, {}, nil, :hash).should == {"test" => "value"}
+      end
+    end
+  end
 end

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -1,84 +1,84 @@
 require 'spec_helper'
 
 class Hiera
-    describe Config do
-        describe "#load" do
-            it "should treat string sources as a filename" do
-                expect {
-                    Config.load("/nonexisting")
-                }.to raise_error("Config file /nonexisting not found")
-            end
+  describe Config do
+    describe "#load" do
+      it "should treat string sources as a filename" do
+        expect {
+            Config.load("/nonexisting")
+        }.to raise_error("Config file /nonexisting not found")
+      end
 
-            it "should raise error for missing config files" do
-                File.expects(:exist?).with("/nonexisting").returns(false)
-                YAML.expects(:load_file).with("/nonexisting").never
+      it "should raise error for missing config files" do
+        File.expects(:exist?).with("/nonexisting").returns(false)
+        YAML.expects(:load_file).with("/nonexisting").never
 
-                expect { Config.load("/nonexisting") }.should raise_error RuntimeError, /not found/
-            end
+        expect { Config.load("/nonexisting") }.should raise_error RuntimeError, /not found/
+      end
 
-            it "should attempt to YAML load config files" do
-                File.expects(:exist?).with("/nonexisting").returns(true)
-                YAML.expects(:load_file).with("/nonexisting").returns(YAML.load("---\n"))
+      it "should attempt to YAML load config files" do
+        File.expects(:exist?).with("/nonexisting").returns(true)
+        YAML.expects(:load_file).with("/nonexisting").returns(YAML.load("---\n"))
 
-                Config.load("/nonexisting")
-            end
+        Config.load("/nonexisting")
+      end
 
-            it "should use defaults on empty YAML config file" do
-                File.expects(:exist?).with("/nonexisting").returns(true)
-                YAML.expects(:load_file).with("/nonexisting").returns(YAML.load(""))
+      it "should use defaults on empty YAML config file" do
+        File.expects(:exist?).with("/nonexisting").returns(true)
+        YAML.expects(:load_file).with("/nonexisting").returns(YAML.load(""))
 
-                Config.load("/nonexisting").should == {:backends => ["yaml"], :hierarchy => "common", :logger => "console"}
-            end
+        Config.load("/nonexisting").should == {:backends => ["yaml"], :hierarchy => "common", :logger => "console"}
+      end
 
-            it "should use hash data as source if supplied" do
-                config = Config.load({"rspec" => "test"})
-                config["rspec"].should == "test"
-            end
+      it "should use hash data as source if supplied" do
+        config = Config.load({"rspec" => "test"})
+        config["rspec"].should == "test"
+      end
 
-            it "should merge defaults with the loaded or supplied config" do
-                config = Config.load({})
-                config.should == {:backends => ["yaml"], :hierarchy => "common", :logger => "console"}
-            end
+      it "should merge defaults with the loaded or supplied config" do
+        config = Config.load({})
+        config.should == {:backends => ["yaml"], :hierarchy => "common", :logger => "console"}
+      end
 
-            it "should force :backends to be a flattened array" do
-                Config.load({:backends => [["foo", ["bar"]]]}).should == {:backends => ["foo", "bar"], :hierarchy => "common", :logger => "console"}
-            end
+      it "should force :backends to be a flattened array" do
+        Config.load({:backends => [["foo", ["bar"]]]}).should == {:backends => ["foo", "bar"], :hierarchy => "common", :logger => "console"}
+      end
 
-            it "should load the supplied logger" do
-                Hiera.expects(:logger=).with("foo")
-                Config.load({:logger => "foo"})
-            end
+      it "should load the supplied logger" do
+        Hiera.expects(:logger=).with("foo")
+        Config.load({:logger => "foo"})
+      end
 
-            it "should default to the console logger" do
-                Hiera.expects(:logger=).with("console")
-                Config.load({})
-            end
-        end
-
-        describe "#load_backends" do
-            it "should load each backend" do
-                Config.load(:backends => ["One", "Two"])
-                Config.expects(:require).with("hiera/backend/one_backend")
-                Config.expects(:require).with("hiera/backend/two_backend")
-                Config.load_backends
-            end
-
-            it "should warn if it cant load a backend" do
-                Config.load(:backends => ["one"])
-                Config.expects(:require).with("hiera/backend/one_backend").raises("fail")
-
-                expect {
-                    Config.load_backends
-                }.to raise_error("fail")
-            end
-        end
-
-        describe "#include?" do
-            it "should correctly report inclusion" do
-                Config.load({})
-                Config.include?(:foo).should == false
-                Config.include?(:logger).should == true
-            end
-        end
+      it "should default to the console logger" do
+        Hiera.expects(:logger=).with("console")
+        Config.load({})
+      end
     end
+
+    describe "#load_backends" do
+      it "should load each backend" do
+        Config.load(:backends => ["One", "Two"])
+        Config.expects(:require).with("hiera/backend/one_backend")
+        Config.expects(:require).with("hiera/backend/two_backend")
+        Config.load_backends
+      end
+
+      it "should warn if it cant load a backend" do
+        Config.load(:backends => ["one"])
+        Config.expects(:require).with("hiera/backend/one_backend").raises("fail")
+
+        expect {
+            Config.load_backends
+        }.to raise_error("fail")
+      end
+    end
+
+    describe "#include?" do
+      it "should correctly report inclusion" do
+        Config.load({})
+        Config.include?(:foo).should == false
+        Config.include?(:logger).should == true
+      end
+    end
+  end
 end

--- a/spec/unit/console_logger_spec.rb
+++ b/spec/unit/console_logger_spec.rb
@@ -1,19 +1,19 @@
 require 'spec_helper'
 
 class Hiera
-    describe Console_logger do
-        describe "#warn" do
-            it "should warn to STDERR" do
-                STDERR.expects(:puts).with("WARN: 0: foo")
-                Time.expects(:now).returns(0)
-                Console_logger.warn("foo")
-            end
+  describe Console_logger do
+    describe "#warn" do
+      it "should warn to STDERR" do
+        STDERR.expects(:puts).with("WARN: 0: foo")
+        Time.expects(:now).returns(0)
+        Console_logger.warn("foo")
+      end
 
-            it "should debug to STDERR" do
-                STDERR.expects(:puts).with("DEBUG: 0: foo")
-                Time.expects(:now).returns(0)
-                Console_logger.debug("foo")
-            end
-        end
+      it "should debug to STDERR" do
+        STDERR.expects(:puts).with("DEBUG: 0: foo")
+        Time.expects(:now).returns(0)
+        Console_logger.debug("foo")
+      end
     end
+  end
 end

--- a/spec/unit/hiera_spec.rb
+++ b/spec/unit/hiera_spec.rb
@@ -1,59 +1,59 @@
 require 'spec_helper'
 
 describe "Hiera" do
-    describe "#logger=" do
-        it "should attempt to load the supplied logger" do
-            Hiera.stubs(:warn)
-            Hiera.expects(:require).with("hiera/foo_logger").raises("fail")
-            Hiera.logger = "foo"
-        end
-
-        it "should fall back to the Console logger on failure" do
-            Hiera.expects(:warn).with("Failed to load foo logger: LoadError: no such file to load -- hiera/foo_logger")
-            Hiera.logger = "foo"
-        end
+  describe "#logger=" do
+    it "should attempt to load the supplied logger" do
+      Hiera.stubs(:warn)
+      Hiera.expects(:require).with("hiera/foo_logger").raises("fail")
+      Hiera.logger = "foo"
     end
 
-    describe "#warn" do
-        it "should call the supplied logger" do
-            Hiera::Console_logger.expects(:warn).with("rspec")
-            Hiera.warn("rspec")
-        end
+    it "should fall back to the Console logger on failure" do
+      Hiera.expects(:warn).with("Failed to load foo logger: LoadError: no such file to load -- hiera/foo_logger")
+      Hiera.logger = "foo"
+    end
+  end
+
+  describe "#warn" do
+    it "should call the supplied logger" do
+      Hiera::Console_logger.expects(:warn).with("rspec")
+      Hiera.warn("rspec")
+    end
+  end
+
+  describe "#debug" do
+    it "should call the supplied logger" do
+      Hiera::Console_logger.expects(:debug).with("rspec")
+      Hiera.debug("rspec")
+    end
+  end
+
+  describe "#initialize" do
+    it "should default to /etc/hiera.yaml for config" do
+      Hiera::Config.expects(:load).with("/etc/hiera.yaml")
+      Hiera::Config.stubs(:load_backends)
+      Hiera.new
     end
 
-    describe "#debug" do
-        it "should call the supplied logger" do
-            Hiera::Console_logger.expects(:debug).with("rspec")
-            Hiera.debug("rspec")
-        end
+    it "should pass the supplied config to the config class" do
+      Hiera::Config.expects(:load).with({"test" => "rspec"})
+      Hiera::Config.stubs(:load_backends)
+      Hiera.new(:config => {"test" => "rspec"})
     end
 
-    describe "#initialize" do
-        it "should default to /etc/hiera.yaml for config" do
-            Hiera::Config.expects(:load).with("/etc/hiera.yaml")
-            Hiera::Config.stubs(:load_backends)
-            Hiera.new
-        end
-
-        it "should pass the supplied config to the config class" do
-            Hiera::Config.expects(:load).with({"test" => "rspec"})
-            Hiera::Config.stubs(:load_backends)
-            Hiera.new(:config => {"test" => "rspec"})
-        end
-
-        it "should load all backends on start" do
-            Hiera::Config.stubs(:load)
-            Hiera::Config.expects(:load_backends)
-            Hiera.new
-        end
+    it "should load all backends on start" do
+      Hiera::Config.stubs(:load)
+      Hiera::Config.expects(:load_backends)
+      Hiera.new
     end
+  end
 
-    describe "#lookup" do
-        it "should proxy to the Backend#lookup method" do
-            Hiera::Config.stubs(:load)
-            Hiera::Config.stubs(:load_backends)
-            Hiera::Backend.expects(:lookup).with(:key, :default, :scope, :order_override, :resolution_type)
-            Hiera.new.lookup(:key, :default, :scope, :order_override, :resolution_type)
-        end
+  describe "#lookup" do
+    it "should proxy to the Backend#lookup method" do
+      Hiera::Config.stubs(:load)
+      Hiera::Config.stubs(:load_backends)
+      Hiera::Backend.expects(:lookup).with(:key, :default, :scope, :order_override, :resolution_type)
+      Hiera.new.lookup(:key, :default, :scope, :order_override, :resolution_type)
     end
+  end
 end

--- a/tasks/release.rb
+++ b/tasks/release.rb
@@ -6,8 +6,8 @@ def get_current_version
 end
 
 def described_version
-    # This ugly bit removes the gSHA1 portion of the describe as that causes failing tests
-    %x{git describe}.gsub('-', '.').split('.')[0..3].join('.').to_s.gsub('v', '')
+  # This ugly bit removes the gSHA1 portion of the describe as that causes failing tests
+  %x{git describe}.gsub('-', '.').split('.')[0..3].join('.').to_s.gsub('v', '')
 end
 
 namespace :pkg do


### PR DESCRIPTION
Before this patch the hiera code base used two different number of
spaces to indent code. In some cases 2 spaces where used, and the rest 4
spaces.

This patch normalizes the number of spaces used for indenting code, and
now uses 2 spaces which is in-line with the Puppetlabs style guide.
