### PR TITLE
Parse hiera.yaml at load-time

### DIFF
--- a/lib/hiera/config.rb
+++ b/lib/hiera/config.rb
@@ -5,14 +5,14 @@ class Hiera::Config
         #
         # Unless specified it will only use YAML as backend with a single
         # 'common' hierarchy and console logger
-        def load(source)
+        def load(source, scope = {})
             @config = {:backends => "yaml",
                        :hierarchy => "common"}
 
             if source.is_a?(String)
                 raise "Config file #{source} not found" unless File.exist?(source)
 
-                config = YAML.load_file(source)
+                config = YAML.load(Hiera.parse_string(File.read(source), scope))
                 @config.merge! config if config
             elsif source.is_a?(Hash)
                 @config.merge! source
@@ -26,6 +26,8 @@ class Hiera::Config
                 @config[:logger] = "console"
                 Hiera.logger = "console"
             end
+
+            Hiera.debug "Hiera config: #{@config.inspect}"
 
             @config
         end

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -2,6 +2,11 @@ require 'spec_helper'
 
 class Hiera
     describe Config do
+        before do
+            Hiera.stubs(:debug)
+            Hiera.stubs(:warn)
+        end
+
         describe "#load" do
             it "should treat string sources as a filename" do
                 expect {
@@ -18,14 +23,14 @@ class Hiera
 
             it "should attempt to YAML load config files" do
                 File.expects(:exist?).with("/nonexisting").returns(true)
-                YAML.expects(:load_file).with("/nonexisting").returns(YAML.load("---\n"))
+                File.expects(:read).with("/nonexisting").returns("---\n")
 
                 Config.load("/nonexisting")
             end
 
             it "should use defaults on empty YAML config file" do
                 File.expects(:exist?).with("/nonexisting").returns(true)
-                YAML.expects(:load_file).with("/nonexisting").returns(YAML.load(""))
+                File.expects(:read).with("/nonexisting").returns("")
 
                 Config.load("/nonexisting").should == {:backends => ["yaml"], :hierarchy => "common", :logger => "console"}
             end


### PR DESCRIPTION
Before this commit `hiera.yaml` is loaded as yaml at runtime in an
atomic operation, but I desired to be able to take scope into account
for the purpose of adding yaml refereces and anchors.

With this commit, Hiera will read the contents of the `hiera.yaml`
config file, parse the contents for `%{strings}`, and then parse the
resulting file from yaml into ruby datastructures.

The Big Why: Discreet hierarchies now available!

``` yaml

---
:hierarchies:
- &testing
    - %{developer}
    - %{operatingsystem}
    - common
- &production
    - %{operatingsystem}
    - common

:hierarchy: *%{environment}
:backends:
    - yaml
:yaml:
    :datadir: "/etc/puppetlabs/puppet/environments/%{environment}/hieradata"
```

This commit is a bit of a refactor. Here is what I did to accomplish
this:
- Move `parse_string` from `Hiera::Backend` to `Hiera`
  - This method is used by both `Hiera::Config` and `Hiera::Backend`
- Allow `scope` to be passed into the `Hiera` constructor
- Use the `scope` when loading `hiera.yaml`

All tests pass.
