### PR TITLE
Differentiate between unique and non-unique array search

### DIFF
--- a/bin/hiera
+++ b/bin/hiera
@@ -116,6 +116,10 @@ OptionParser.new do |opts|
     options[:resolution_type] = :array
   end
 
+  opts.on("--unique", "-u", "Unique array search") do
+    options[:resolution_type] = :unique_array
+  end
+
   opts.on("--hash", "-h", "Hash search") do
     options[:resolution_type] = :hash
   end

--- a/lib/hiera/backend.rb
+++ b/lib/hiera/backend.rb
@@ -129,6 +129,8 @@ class Hiera
       def resolve_answer(answer, resolution_type)
         case resolution_type
         when :array
+          [answer].flatten.compact
+        when :unique_array
           [answer].flatten.uniq.compact
         when :hash
           answer # Hash structure should be preserved


### PR DESCRIPTION
A small patch to add an option to allow for non-unique array search by default, and a different unique array search.
