### PR TITLE
Fix VERSION contant in lib/hiera.rb

### DIFF
--- a/lib/hiera.rb
+++ b/lib/hiera.rb
@@ -2,7 +2,7 @@ require 'rubygems'
 require 'yaml'
 
 class Hiera
-  VERSION = "0.2.1"
+  VERSION = "0.3.0"
 
   autoload :Config, "hiera/config"
   autoload :Backend, "hiera/backend"


### PR DESCRIPTION
When the gem is packaged up, the VERSION field is created based on the
last signed tag from this git repository; however after that change
happened and the gem was shipped, I foolishly forgot to commit that
change so the lib/hiera.rb file thought it was still at 0.2.1 even
though it was really at 0.3.0. This fixes my mistake.

Signed-off-by: Michael Stahnke stahnma@puppetlabs.com
