### PR TITLE
Bug #12122 fix

### DIFF
--- a/lib/hiera/backend.rb
+++ b/lib/hiera/backend.rb
@@ -175,7 +175,7 @@ class Hiera
         answer = resolve_answer(answer, resolution_type)
         answer = parse_string(default, scope) if answer.nil?
 
-        return default if answer == empty_answer(resolution_type)
+        return default if answer == empty_answer(resolution_type) unless default.nil?
         return answer
       end
     end


### PR DESCRIPTION
The lookup method cannot return nil in case there isn't an available answer. Instead, an empty data structure ("", [] or {}) will be returned. Also, calling hiera_array and hiera_hash should return all results from all backends.
