### PR TITLE
Bug #12122 fix

### DIFF
--- a/lib/hiera/backend.rb
+++ b/lib/hiera/backend.rb
@@ -160,7 +160,7 @@ class Hiera
             new_answer = @backends[backend].lookup(key, scope, order_override, resolution_type)
             case resolution_type
               when :priority
-                answer = new_answer unless !new_answer.nil?
+                answer = new_answer unless new_answer.nil?
                 break if answer != empty_answer(:priority)
               when :array
                 answer << new_answer


### PR DESCRIPTION
The lookup method cannot return nil in case there isn't an available answer. Instead, an empty data structure ("", [] or {}) will be returned. Also, calling hiera_array and hiera_hash should return all results from all backends.
