### PR TITLE
Implement caching on YAML Backend

### DIFF
--- a/lib/hiera/backend/yaml_backend.rb
+++ b/lib/hiera/backend/yaml_backend.rb
@@ -3,8 +3,9 @@ class Hiera
     class Yaml_backend
       def initialize
         require 'yaml'
-
         Hiera.debug("Hiera YAML backend starting")
+        @data  = Hash.new
+        @cache = Hash.new
       end
 
       def lookup(key, scope, order_override, resolution_type)
@@ -14,21 +15,28 @@ class Hiera
 
         Backend.datasources(scope, order_override) do |source|
           Hiera.debug("Looking for data source #{source}")
-
           yamlfile = Backend.datafile(:yaml, scope, source, "yaml") || next
 
-          data = YAML.load_file(yamlfile)
+          # If you call stale? BEFORE you do encounter the YAML.load_file line
+          # it will populate the @cache variable and return true. The second
+          # time you call it, it will return false because @cache has been
+          # populated. Because of this there are two conditions to check:
+          # is @data[yamlfile] populated AND is the cache stale.
+          if @data[yamlfile]
+            @data[yamlfile] = YAML.load_file(yamlfile) if stale?(yamlfile)
+          else
+            @data[yamlfile] = YAML.load_file(yamlfile)
+          end
 
-          next if ! data
-          next if data.empty?
-          next unless data.include?(key)
-
+          next if ! @data[yamlfile]
+          next if @data[yamlfile].empty?
+          next unless @data[yamlfile].include?(key)
           # for array resolution we just append to the array whatever
           # we find, we then goes onto the next file and keep adding to
           # the array
           #
           # for priority searches we break after the first found data item
-          new_answer = Backend.parse_answer(data[key], scope)
+          new_answer = Backend.parse_answer(@data[yamlfile][key], scope)
           case resolution_type
           when :array
             raise Exception, "Hiera type mismatch: expected Array and got #{new_answer.class}" unless new_answer.kind_of? Array or new_answer.kind_of? String
@@ -43,6 +51,18 @@ class Hiera
         end
 
         return answer
+      end
+
+      def stale?(yamlfile)
+        # NOTE: The mtime change in a file MUST be > 1 second before being
+        #       recognized as stale. File mtime changes within 1 second will
+        #       not be recognized.
+        stat    = File.stat(yamlfile)
+        current = { 'inode' => stat.ino, 'mtime' => stat.mtime, 'size' => stat.size }
+        return false if @cache[yamlfile] == current
+
+        @cache[yamlfile] = current
+        return true
       end
     end
   end


### PR DESCRIPTION
Previously, the YAML backend would read from disk every time it needed
to check a hierarchy. This commit introduces memoization through an
instance variable so a file is read only if the instance variable is
empty, and only if the file has not changed. To check if the file has
changed (or if the cache is stale), we stat the file and compare the
mtime, size, and inode. Tests have been added for this new
functionality.

Fix Bugs and Commit Tests
