### PR TITLE
(#14147) Handle lack of rubygems gracefully

### DIFF
--- a/bin/hiera
+++ b/bin/hiera
@@ -11,7 +11,10 @@
 #
 # $ hiera release 'rel/%{location}' location=dc2 --yaml some.node.yaml
 
-require 'rubygems'
+begin
+  require 'rubygems'
+rescue LoadError
+end
 require 'hiera'
 require 'optparse'
 

--- a/lib/hiera.rb
+++ b/lib/hiera.rb
@@ -1,4 +1,7 @@
-require 'rubygems'
+begin
+  require 'rubygems'
+rescue LoadError
+end
 require 'yaml'
 
 class Hiera


### PR DESCRIPTION
Hiera previously expected rubygems to be available. When running from source or
a package, rubygems may not be available. This fix rescues the load error on
rubygem and silently ignores it so that if rubygems is present, it can be used,
but if it isn't present, hiera can still function.
(Borrowed the method used in puppet)
