### PR TITLE
(#14150) Use tar_gz instead of tar

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -21,7 +21,7 @@ spec = Gem::Specification.new do |s|
 end
 
 Gem::PackageTask.new(spec) do |pkg|
-  pkg.need_tar = true
+  pkg.need_tar_gz = true
 end
 
 desc "Run all specs"


### PR DESCRIPTION
This replaces tar with tar_gz so that the package task will produce tar.gz
instead of .tgz, which is more in line with other puppet products.
