### PR TITLE
(maint) Fix failing spec test on Ruby 1.9.3

### DIFF
--- a/lib/hiera.rb
+++ b/lib/hiera.rb
@@ -10,6 +10,8 @@ class Hiera
   autoload :Puppet_logger, "hiera/puppet_logger"
 
   class << self
+    attr_reader :logger
+
     def version
       VERSION
     end

--- a/spec/unit/hiera_spec.rb
+++ b/spec/unit/hiera_spec.rb
@@ -9,8 +9,9 @@ describe "Hiera" do
     end
 
     it "should fall back to the Console logger on failure" do
-      Hiera.expects(:warn).with("Failed to load foo logger: LoadError: no such file to load -- hiera/foo_logger")
+      Hiera.expects(:warn)
       Hiera.logger = "foo"
+      Hiera.logger.should be Hiera::Console_logger
     end
   end
 


### PR DESCRIPTION
Without this patch the specs tests do no pass on Ruby 1.9. The output
for `Load Errors` has changed between Ruby 1.8.7 and 1.9.3. This causes
the `Hiera#logger` spec to fail on Ruby 1.9.3 as we are relying on the
output from 1.8.7.

Instead of relying on a string which is subject to change in the future,
we are now checking that the correct logger is being used.
