### PR TITLE
(maint) Make noop logger work on Ruby 1.9.x

### DIFF
--- a/bin/hiera
+++ b/bin/hiera
@@ -18,14 +18,14 @@ end
 require 'hiera'
 require 'optparse'
 
-options = {:default => nil, :config => "/etc/hiera.yaml", :scope => {}, :key => nil, :verbose => false, :resolution_type => :priority}
-
-class Hiera::Noop_logger
-  class << self
-    def warn(msg);end
-    def debug(msg);end
-  end
-end
+options = {
+  :default => nil,
+  :config  => "/etc/hiera.yaml",
+  :scope   => {},
+  :key     => nil,
+  :verbose => false,
+  :resolution_type => :priority
+}
 
 # Loads the scope from YAML or JSON files
 def load_scope(source, type=:yaml)

--- a/lib/hiera.rb
+++ b/lib/hiera.rb
@@ -7,10 +7,11 @@ require 'yaml'
 class Hiera
   VERSION = "0.3.0"
 
-  autoload :Config, "hiera/config"
-  autoload :Backend, "hiera/backend"
+  autoload :Config,         "hiera/config"
+  autoload :Backend,        "hiera/backend"
   autoload :Console_logger, "hiera/console_logger"
-  autoload :Puppet_logger, "hiera/puppet_logger"
+  autoload :Puppet_logger,  "hiera/puppet_logger"
+  autoload :Noop_logger,    "hiera/noop_logger"
 
   class << self
     attr_reader :logger

--- a/lib/hiera/noop_logger.rb
+++ b/lib/hiera/noop_logger.rb
@@ -1,0 +1,8 @@
+class Hiera
+  module Noop_logger
+    class << self
+      def warn(msg);end
+      def debug(msg);end
+    end
+  end
+end

--- a/lib/hiera/puppet_logger.rb
+++ b/lib/hiera/puppet_logger.rb
@@ -1,8 +1,13 @@
 class Hiera
   module Puppet_logger
     class << self
-      def warn(msg); Puppet.notice("hiera(): #{msg}"); end
-      def debug(msg); Puppet.debug("hiera(): #{msg}"); end
+      def warn(msg)
+        Puppet.notice("hiera(): #{msg}")
+      end
+
+      def debug(msg)
+        Puppet.debug("hiera(): #{msg}")
+      end
     end
   end
 end


### PR DESCRIPTION
With out this patch the noop logger does not load on Ruby 1.9.x when
running Hiera from the CLI. Instead we get the follow error:

```
LoadError: cannot load such file -- hiera/noop_logger
```

This patch resolves this issue by moving the noop_logger definition from
`bin/hiera` to `lib/hiera/noop_logger.rb`
