### PR TITLE
(#14256) Adding save API

### DIFF
--- a/lib/hiera.rb
+++ b/lib/hiera.rb
@@ -24,7 +24,7 @@ class Hiera
     # Hiera::Foo_logger and respond to :warn and :debug
     #
     # See hiera-puppet for an example that uses the Puppet
-    # loging system instead of our own
+    # logging system instead of our own
     def logger=(logger)
       loggerclass = "#{logger.capitalize}_logger"
 
@@ -63,5 +63,33 @@ class Hiera
   # of your choice.
   def lookup(key, default, scope, order_override=nil, resolution_type=:priority)
     Backend.lookup(key, default, scope, order_override, resolution_type)
+  end
+
+  # Calls the backend to do the actual save.
+  #
+  # The backend should match one of the configured backend plugins by name.
+  #
+  # The source can be any of the items in the hierarchy. For example, if you
+  # have the following hierarchy:
+  #
+  #   :hierarchy:
+  #     - %{environment}
+  #     - common
+  #
+  # And the following scope:
+  #
+  #   { 'environment' => 'production' }
+  #
+  # The source should be either 'common', 'production', or any value you
+  # expect to be matched by %{environment}.
+  def save(key, value, backend, source)
+    Backend.save(key, value, backend, source)
+  end
+
+  # Calls the backend to do the actual delete.
+  #
+  # Works like the save method, but deletes data instead.
+  def delete(key, value, backend, source)
+    Backend.delete(key, value, backend, source)
   end
 end

--- a/lib/hiera/backend.rb
+++ b/lib/hiera/backend.rb
@@ -176,6 +176,38 @@ class Hiera
         return default if answer == empty_answer(resolution_type)
         return answer
       end
+
+      # Saves data to the specified backend. Returns status of the action.
+      def save(key, value, backend, source)
+        execute(key, value, backend, source, :save)
+      end
+
+      # Deletes data from the specified backend. Returns status of the action.
+      def delete(key, value, backend, source)
+        execute(key, value, backend, source, :delete)
+      end
+
+      private
+
+      # Calls out to the specified backend to perform an action.
+      def execute(key, value, backend, source, action)
+        status = false
+
+        if constants.include?("#{backend.capitalize}_backend") ||
+           constants.include?("#{backend.capitalize}_backend".to_sym)
+          dest = Backend.const_get("#{backend.capitalize}_backend").new
+
+          if dest.respond_to?(action)
+            status = dest.send(action, key, value, source)
+          else
+            Hiera.warn("Cannot #{action} data, #{backend} backend does not support #{action}")
+          end
+        else
+          Hiera.warn("Cannot #{action} data, #{backend} is not a valid backend")
+        end
+
+        return status
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,3 +17,12 @@ class Puppet
   end
 end
 
+class Hiera
+  module Backend
+    class Test_backend
+      def initialize
+        Hiera.debug("Hiera Test backend starting")
+      end
+    end
+  end
+end

--- a/spec/unit/backend_spec.rb
+++ b/spec/unit/backend_spec.rb
@@ -284,5 +284,57 @@ class Hiera
         Backend.lookup("key", {"test" => "value"}, {}, nil, :hash).should == {"test" => "value"}
       end
     end
+
+    describe "#save" do
+      before do
+        Hiera.stubs(:debug)
+        Hiera.stubs(:warn)
+      end
+
+      it "should warn if the backend is not valid" do
+        Config.load({})
+        Hiera.expects(:warn).with("Cannot save data, nobackend is not a valid backend")
+        Backend.save("key", "value", "nobackend", "source")
+      end
+
+      it "should warn if the backend does not support save" do
+        Config.load({})
+        Hiera.expects(:warn).with("Cannot save data, test backend does not support save")
+        Backend.save("key", "value", "test", "source").should be_false
+      end
+
+      it "should return the status from the backend" do
+        Config.load({})
+        Hiera::Backend::Test_backend.any_instance.expects(:save).
+          with("key", "value", "source").returns(true)
+        Backend.save("key", "value", "test", "source").should be_true
+      end
+    end
+
+    describe "#delete" do
+      before do
+        Hiera.stubs(:debug)
+        Hiera.stubs(:warn)
+      end
+
+      it "should warn if the backend is not valid" do
+        Config.load({})
+        Hiera.expects(:warn).with("Cannot delete data, nobackend is not a valid backend")
+        Backend.delete("key", "value", "nobackend", "source")
+      end
+
+      it "should warn if the backend does not support delete" do
+        Config.load({})
+        Hiera.expects(:warn).with("Cannot delete data, test backend does not support delete")
+        Backend.delete("key", "value", "test", "source").should be_false
+      end
+
+      it "should return the status from the backend" do
+        Config.load({})
+        Hiera::Backend::Test_backend.any_instance.expects(:delete).
+          with("key", "value", "source").returns(true)
+        Backend.delete("key", "value", "test", "source").should be_true
+      end
+    end
   end
 end

--- a/spec/unit/hiera_spec.rb
+++ b/spec/unit/hiera_spec.rb
@@ -57,4 +57,22 @@ describe "Hiera" do
       Hiera.new.lookup(:key, :default, :scope, :order_override, :resolution_type)
     end
   end
+
+  describe "#save" do
+    it "should proxy to the Backend#save method" do
+      Hiera::Config.stubs(:load)
+      Hiera::Config.stubs(:load_backends)
+      Hiera::Backend.expects(:save).with(:key, :value, :backend, :source)
+      Hiera.new.save(:key, :value, :backend, :source)
+    end
+  end
+
+  describe "#delete" do
+    it "should proxy to the Backend#delete method" do
+      Hiera::Config.stubs(:load)
+      Hiera::Config.stubs(:load_backends)
+      Hiera::Backend.expects(:delete).with(:key, :value, :backend, :source)
+      Hiera.new.delete(:key, :value, :backend, :source)
+    end
+  end
 end


### PR DESCRIPTION
This patch adds a new API for saving data by delegating to a specific
backend. The backend is responsible for saving data based on a key,
value, and source. The backend must return a status response of true
or false depending on the success or failure of the save operation.

Example:

If we have the following Hiera configuration:

   :hierarchy:
     - %{environment}
     - common

   :backends:
     - backend_with_save_support

We can save data to the `backend_with_save_support` like this:

```
require 'hiera'

hiera = Hiera.new
status = hiera.save('key, 'value', 'backend_with_save_support', 'common')
```

This patch includes tests.
