### PR TITLE
(#13600) Monkey patch mktmpdir on ruby 1.8.5

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,3 +17,46 @@ class Puppet
   end
 end
 
+# In ruby 1.8.5 Dir does not have mktmpdir defined, so this monkey patches
+# Dir to include the 1.8.7 definition of that method if it isn't already defined.
+# Method definition borrowed from ruby-1.8.7-p357/lib/ruby/1.8/tmpdir.rb
+unless Dir.respond_to?(:mktmpdir)
+  def Dir.mktmpdir(prefix_suffix=nil, tmpdir=nil)
+    case prefix_suffix
+    when nil
+      prefix = "d"
+      suffix = ""
+    when String
+      prefix = prefix_suffix
+      suffix = ""
+    when Array
+      prefix = prefix_suffix[0]
+      suffix = prefix_suffix[1]
+    else
+      raise ArgumentError, "unexpected prefix_suffix: #{prefix_suffix.inspect}"
+    end
+    tmpdir ||= Dir.tmpdir
+    t = Time.now.strftime("%Y%m%d")
+    n = nil
+    begin
+      path = "#{tmpdir}/#{prefix}#{t}-#{$$}-#{rand(0x100000000).to_s(36)}"
+      path << "-#{n}" if n
+      path << suffix
+      Dir.mkdir(path, 0700)
+    rescue Errno::EEXIST
+      n ||= 0
+      n += 1
+      retry
+    end
+
+    if block_given?
+      begin
+        yield path
+      ensure
+        FileUtils.remove_entry_secure path
+      end
+    else
+      path
+    end
+  end
+end

--- a/spec/unit/backend/yaml_backend_spec.rb
+++ b/spec/unit/backend/yaml_backend_spec.rb
@@ -1,7 +1,7 @@
-require 'spec_helper'
 require 'tmpdir'
 require 'hiera/backend/yaml_backend'
 require 'fileutils'
+require 'spec_helper'
 
 class Hiera
   module Backend


### PR DESCRIPTION
The yaml_backend spec test uses mktmpdir in its tests, which is not available
on ruby 1.8.5. This fix defines mktmpdir using the 1.8.7 method if the method
is not available, as is the case in ruby 1.8.5. It defines the method if needed
in the spec_helper file, and the requires in the yaml_backend_spec are
reordered to ensure that spec_helper is required last, so that it will know if
mktmpdir needs to be defined.
