### PR TITLE
Allow hierarchy levels to be expanded by array values

### DIFF
--- a/lib/hiera/backend.rb
+++ b/lib/hiera/backend.rb
@@ -56,8 +56,11 @@ class Hiera
         hierarchy.insert(0, override) if override
 
         hierarchy.flatten.map do |source|
-          source = parse_string(source, scope)
-          yield(source) unless source == "" or source =~ /(^\/|\/\/|\/$)/
+          if sources = parse_string(source, scope)
+            sources.each do |source|
+              yield(source) unless source == "" or source =~ /(^\/|\/\/|\/$)/
+            end
+          end
         end
       end
 
@@ -76,7 +79,7 @@ class Hiera
         tdata = data.clone
 
         if tdata.is_a?(String)
-          while tdata =~ /%\{(.+?)\}/
+          while Array(tdata).join('|') =~ /%\{([^|]+?)\}/
             begin
               var = $1
 
@@ -92,7 +95,13 @@ class Hiera
               end
             end until val != "" || var !~ /::(.+)/
 
-            tdata.gsub!(/%\{(::)?#{var}\}/, val)
+            if tdata.is_a?(Array)
+              tdata = tdata.map { |elem| parse_string(elem, scope, extra_data) }.flatten
+            elsif val.is_a?(Array)
+              tdata = val.map { |elem| tdata.gsub(/%\{(::)?#{var}\}/, elem) }
+            else
+              tdata.gsub!(/%\{(::)?#{var}\}/, val)
+            end
           end
         end
 


### PR DESCRIPTION
Sometimes array values such as $roles will be used in a given hierarchy
level for Hiera. This commit will expand the level containing %{roles}
into a row for each value of $roles in order of the given array.
