### PR TITLE
(#14460) Add Puppet parser functions

### DIFF
--- a/lib/puppet/parser/functions/hiera.rb
+++ b/lib/puppet/parser/functions/hiera.rb
@@ -1,0 +1,45 @@
+module Puppet::Parser::Functions
+  newfunction(:hiera, :type => :rvalue) do |*args|
+    # Functions called from puppet manifests that look like this:
+    #   lookup("foo", "bar")
+    # internally in puppet are invoked:  func(["foo", "bar"])
+    #
+    # where as calling from templates should work like this:
+    #   scope.function_lookup("foo", "bar")
+    #
+    #  Therefore, declare this function with args '*args' to accept any number
+    #  of arguments and deal with puppet's special calling mechanism now:
+    if args[0].is_a?(Array)
+      args = args[0]
+    end
+
+    key = args[0]
+    default = args[1]
+    override = args[2]
+
+    configfile = File.join([File.dirname(Puppet.settings[:config]), "hiera.yaml"])
+
+    raise(Puppet::ParseError, "Hiera config file #{configfile} not readable") unless File.exist?(configfile)
+
+    require 'hiera'
+    require 'hiera/scope'
+
+    config = YAML.load_file(configfile)
+    config[:logger] = "puppet"
+
+    hiera = Hiera.new(:config => config)
+
+    if self.respond_to?("[]")
+      hiera_scope = self
+    else
+      hiera_scope = Hiera::Scope.new(self)
+    end
+
+    answer = hiera.lookup(key, default, hiera_scope, override, :priority)
+
+    raise(Puppet::ParseError, "Could not find data item #{key} in any Hiera data file and no default supplied") if answer.nil?
+
+    return answer
+  end
+end
+

--- a/lib/puppet/parser/functions/hiera_array.rb
+++ b/lib/puppet/parser/functions/hiera_array.rb
@@ -1,0 +1,35 @@
+module Puppet::Parser::Functions
+  newfunction(:hiera_array, :type => :rvalue) do |*args|
+    if args[0].is_a?(Array)
+      args = args[0]
+    end
+
+    key = args[0]
+    default = args[1]
+    override = args[2]
+
+    configfile = File.join([File.dirname(Puppet.settings[:config]), "hiera.yaml"])
+
+    raise(Puppet::ParseError, "Hiera config file #{configfile} not readable") unless File.exist?(configfile)
+
+    require 'hiera'
+    require 'hiera/scope'
+
+    config = YAML.load_file(configfile)
+    config[:logger] = "puppet"
+
+    hiera = Hiera.new(:config => config)
+
+    if self.respond_to?("[]")
+      hiera_scope = self
+    else
+      hiera_scope = Hiera::Scope.new(self)
+    end
+
+    answer = hiera.lookup(key, default, hiera_scope, override, :array)
+
+    raise(Puppet::ParseError, "Could not find data item #{key} in any Hiera data file and no default supplied") if answer.empty?
+
+    answer
+  end
+end

--- a/lib/puppet/parser/functions/hiera_hash.rb
+++ b/lib/puppet/parser/functions/hiera_hash.rb
@@ -1,0 +1,37 @@
+module Puppet::Parser::Functions
+  newfunction(:hiera_hash, :type => :rvalue) do |*args|
+    if args[0].is_a?(Array)
+      args = args[0]
+    end
+
+    raise(Puppet::ParseError, "Please supply a parameter to perform a Hiera lookup") if args.empty?
+
+    key = args[0]
+    default = args[1]
+    override = args[2]
+
+    configfile = File.join([File.dirname(Puppet.settings[:config]), "hiera.yaml"])
+
+    raise(Puppet::ParseError, "Hiera config file #{configfile} not readable") unless File.exist?(configfile)
+
+    require 'hiera'
+    require 'hiera/scope'
+
+    config = YAML.load_file(configfile)
+    config[:logger] = "puppet"
+
+    hiera = Hiera.new(:config => config)
+
+    if self.respond_to?("{}")
+      hiera_scope = self
+    else
+      hiera_scope = Hiera::Scope.new(self)
+    end
+
+    answer = hiera.lookup(key, default, hiera_scope, override, :hash)
+
+    raise(Puppet::ParseError, "Could not find data item #{key} in any Hiera data file and no default supplied") if answer.empty?
+
+    answer
+  end
+end

--- a/spec/unit/parser/functions/hiera_hash_spec.rb
+++ b/spec/unit/parser/functions/hiera_hash_spec.rb
@@ -1,0 +1,11 @@
+require 'puppet'
+require 'hiera'
+require 'spec_helper'
+
+describe 'Puppet::Parser::Functions#hiera_hash' do
+  it 'should require a key argument' do
+    Puppet::Parser::Functions.function(:hiera_hash)
+    @scope = Puppet::Parser::Scope.new
+    expect { @scope.function_hiera_hash([]) }.should raise_error(Puppet::ParseError)
+  end
+end


### PR DESCRIPTION
This patch bundles the following Puppet parser functions from
hiera-puppet:
- hiera
- hiera_array
- hiera_hash
