### PR TITLE
(#14514) Use default config when hiera.yaml is missing

### DIFF
--- a/lib/hiera/config.rb
+++ b/lib/hiera/config.rb
@@ -10,10 +10,12 @@ class Hiera::Config
                  :hierarchy => "common"}
 
       if source.is_a?(String)
-        raise "Config file #{source} not found" unless File.exist?(source)
-
-        config = YAML.load_file(source)
-        @config.merge! config if config
+        if File.exist?(source)
+          config = YAML.load_file(source)
+          @config.merge! config if config
+        else
+          Hiera.warn "Config file #{source} not found"
+        end
       elsif source.is_a?(Hash)
         @config.merge! source
       end


### PR DESCRIPTION
Hiera no longer raises an exception when the hiera configuration file
is missing; instead log a warning and use the following default config:

```
{
  :backends  => ["yaml"],
  :hierarchy => "common",
  :logger    => "console"
}
```

This patch includes updated tests.
