### PR TITLE
Split RPM to hiera and hiera-puppet

### DIFF
--- a/ext/redhat/hiera.spec
+++ b/ext/redhat/hiera.spec
@@ -22,12 +22,12 @@ Requires:	ruby >= 1.8.5
 %description
 A simple pluggable Hierarchical Database.
 
-%package puppet
+%package puppet-functions
 Summary:        A simple pluggable Hierarchical Database.
 Group:          System Environment/Base
 Requires:       hiera-puppet = %{version}-%{release}
 Requires:       puppet
-%description puppet
+%description puppet-functions
 Functions to call hiera from within puppet.
 
 %prep
@@ -58,7 +58,7 @@ rm -rf $RPM_BUILD_ROOT
 %{ruby_sitelibdir}/hiera
 %doc CHANGELOG COPYING README.md
 
-%files puppet
+%files puppet-functions
 # Puppet hiera functions
 %{ruby_sitelibdir}/puppet/parser/functions/*.rb
 


### PR DESCRIPTION
This updates the spec file to produce two rpms instead of one

hiera  -  the standalone application.
hiera-puppet - the puppet functions.

The motivation here is the second package should I believe depend on puppet always 
where as the first should clearly not.

hiera-puppet of course pulls in hiera.
