### PR TITLE
Add default config to hiera

### DIFF
--- a/ext/debian/rules
+++ b/ext/debian/rules
@@ -17,14 +17,18 @@ LIBDIR=$(shell /usr/bin/ruby -rrbconfig -e 'puts Config::CONFIG["rubylibdir"]')
 RUBYLIB=$(BUILD_ROOT)/$(LIBDIR)
 BIN_DIR=$(BUILD_ROOT)/usr/bin
 DOC_DIR=$(BUILD_ROOT)/usr/share/doc/hiera/
+DATA_DIR=$(BUILD_ROOT)/var/lib/hiera
 
 install/hiera::
 	mkdir -p $(RUBYLIB)
 	mkdir -p $(BIN_DIR)
 	mkdir -p $(DOC_DIR)
+	mkdir -p $(DATA_DIR)
+	mkdir -p $(BUILD_ROOT)/etc
 	cp -pr  lib/hiera $(RUBYLIB)
 	cp -p lib/hiera.rb $(RUBYLIB)
 	cp -p  bin/* $(BIN_DIR)
+	cp -pr ext/hiera.yaml $(BUILD_ROOT)/etc
 	cp -p CHANGELOG COPYING README.md $(DOC_DIR)
 
 clean::

--- a/ext/hiera.yaml
+++ b/ext/hiera.yaml
@@ -1,0 +1,11 @@
+---
+:backend:
+  - yaml
+:hierarchy:
+  - defaults
+  - %{certname}
+  - %{environment}
+  - global
+
+:yaml:
+  :datadir: /var/lib/hiera

--- a/ext/redhat/hiera.spec.erb
+++ b/ext/redhat/hiera.spec.erb
@@ -7,20 +7,20 @@
 # %global realversion <%= version %>
 # %global rpmversion <%= rpmversion %>
 
-Name:		hiera
+Name:           hiera
 Version:        %{rpmversion}
 Release:        <%= release -%>%{?dist}
-Summary:	A simple pluggable Hierarchical Database.
+Summary:        A simple pluggable Hierarchical Database.
 
-Group: 		System Environment/Base
-License: 	Apache 2.0
-URL:		http://projects.puppetlabs.com/projects/%{name}/
-Source0:	http://downloads.puppetlabs.com/%{name}/%{name}-%{realversion}.tar.gz
-BuildRoot: 	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
-BuildArch:	noarch
-BuildRequires:	ruby >= 1.8.5
-Requires:	ruby(abi) >= 1.8	
-Requires:	ruby >= 1.8.5	
+Group:          System Environment/Base
+License:        Apache 2.0
+URL:            http://projects.puppetlabs.com/projects/%{name}/
+Source0:        http://downloads.puppetlabs.com/%{name}/%{name}-%{realversion}.tar.gz
+BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
+BuildArch:      noarch
+BuildRequires:  ruby >= 1.8.5
+Requires:       ruby(abi) >= 1.8
+Requires:       ruby >= 1.8.5
 
 %description
 A simple pluggable Hierarchical Database.
@@ -36,9 +36,12 @@ A simple pluggable Hierarchical Database.
 rm -rf $RPM_BUILD_ROOT
 mkdir -p $RPM_BUILD_ROOT/%{ruby_sitelibdir}
 mkdir -p $RPM_BUILD_ROOT/%{_bindir}
-cp -pr lib/hiera $RPM_BUILD_ROOT/%{ruby_sitelibdir} 
-cp -pr lib/hiera.rb $RPM_BUILD_ROOT/%{ruby_sitelibdir} 
+mkdir -p $RPM_BUILD_ROOT/%{_sysconfdir}
+mkdir -p $RPM_BUILD_ROOT/%{_sharedstatedir}/hiera
+cp -pr lib/hiera $RPM_BUILD_ROOT/%{ruby_sitelibdir}
+cp -pr lib/hiera.rb $RPM_BUILD_ROOT/%{ruby_sitelibdir}
 install -p -m0755 bin/hiera $RPM_BUILD_ROOT/%{_bindir}
+install -p -m0644 ext/hiera.yaml $RPM_BUILD_ROOT/%{_sysconfdir}
 
 %clean
 rm -rf $RPM_BUILD_ROOT
@@ -49,6 +52,8 @@ rm -rf $RPM_BUILD_ROOT
 %{_bindir}/hiera
 %{ruby_sitelibdir}/hiera.rb
 %{ruby_sitelibdir}/hiera
+%{_sysconfdir}/hiera.yaml
+%{_sharedstatedir}/hiera
 %doc CHANGELOG COPYING README.md
 
 

--- a/tasks/apple.rake
+++ b/tasks/apple.rake
@@ -125,12 +125,15 @@ def pack_source
   # Make all necessary directories
   directories = ["#{work}/usr/bin",
                  "#{work}/usr/share/doc/#{@package_name}",
-                 "#{work}/usr/lib/ruby/site_ruby/1.8/#{@package_name}"]
+                 "#{work}/usr/lib/ruby/site_ruby/1.8/#{@package_name}",
+                 "#{work}/var/lib/#{@package_name}",
+                 "#{work}/etc"]
   FileUtils.mkdir_p(directories)
 
   # Install necessary files
   system("#{DITTO} #{source}/bin/ #{work}/usr/bin")
   system("#{DITTO} #{source}/lib/ #{work}/usr/lib/ruby/site_ruby/1.8/")
+  system("#{DITTO} #{source}/ext/hiera.yaml #{work}/etc")
 
   # Setup a preflight script and replace variables in the files with
   # the correct paths.


### PR DESCRIPTION
When run on its own, hiera depends on having a config file present. It expects
/etc/hiera.yaml to exist. This commit adds a default config file to hiera, and
adds the config file to the packages for hiera. It also adds an empty datadir to hiera
package installs.
