### PR TITLE
Comment out datadir in hiera.yaml

### DIFF
--- a/ext/hiera.yaml
+++ b/ext/hiera.yaml
@@ -8,4 +8,6 @@
   - global
 
 :yaml:
-  :datadir: /var/lib/hiera
+# datadir is empty here, so hiera uses its defaults
+# When specifying a datadir, make sure the path of the datadir exists
+  :datadir:


### PR DESCRIPTION
The fully qualified path in hiera.yaml for the datadir works well in linux
installs, but fails in Windows installs. As hiera will fall back to sane
defaults, the datadir can be commented out and still work.
