### PR TITLE
(maint) Hiera now has a LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,18 @@
+Puppet - Automating Configuration Management.
+
+Copyright (C) 2012 Puppet Labs Inc
+
+Puppet Labs can be contacted at: info@puppetlabs.com
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+

--- a/README.md
+++ b/README.md
@@ -230,7 +230,12 @@ When used in Puppet you'd expect Hiera to log using the Puppet infrastructure, t
 plugin includes a Puppet Logger plugin for Hiera that uses the normal Puppet logging
 methods for all logging.
 
-Contact?
-========
+License
+-------
 
-R.I.Pienaar / rip@devco.net / @ripienaar / www.devco.net
+See LICENSE file.
+
+Support
+-------
+Please log tickets and issues at our [Projects site](http://projects.puppetlabs.com)
+


### PR DESCRIPTION
Hiera has always been licensed under the ASL2. This patch makes that
easier to find by adding a "License" section to the README, and a new
LICENSE file.
- ASL2 - Apache License, Version 2.0
