### PR TITLE
Fixup apple package plist for use with packaging repo

### DIFF
--- a/ext/osx/prototype.plist.erb
+++ b/ext/osx/prototype.plist.erb
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<pkg-info>
+<plist>
 <dict>
 	<key>CFBundleIdentifier</key>
 	<string><%= @title %></string>
@@ -35,4 +35,4 @@
 	<key>IFPkgFlagUpdateInstalledLanguages</key>
 	<false/>
 </dict>
-</pkg-info>
+</plist>


### PR DESCRIPTION
With the packaging repo change to the non-flat package
format, the package info plist format changes to plist.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
