### PR TITLE
Edit example hiera.yaml to fix bogus variable and include default datadi...

### DIFF
--- a/ext/hiera.yaml
+++ b/ext/hiera.yaml
@@ -3,11 +3,13 @@
   - yaml
 :hierarchy:
   - defaults
-  - %{certname}
+  - %{clientcert}
   - %{environment}
   - global
 
 :yaml:
-# datadir is empty here, so hiera uses its defaults
-# When specifying a datadir, make sure the path of the datadir exists
+# datadir is empty here, so hiera uses its defaults:
+# - /var/lib/hiera on *nix
+# - %CommonAppData%\PuppetLabs\hiera\var on Windows
+# When specifying a datadir, make sure the directory exists.
   :datadir:


### PR DESCRIPTION
...r

A Puppet scope has no $certname variable, and we don't do anything to add one.
Instead, Puppet has the following two variables:
- $settings::certname - the puppet master's certname
- $clientcert - the agent node's certname

Of the two, we want $clientcert.

This commit also calls out the location of the default datadir.
