### PR TITLE
Update debian packaging for ruby 1.9

### DIFF
--- a/ext/debian/control
+++ b/ext/debian/control
@@ -2,12 +2,12 @@ Source: hiera
 Section: utils
 Priority: extra
 Maintainer: Puppet Labs <info@puppetlabs.com>
-Build-Depends: debhelper (>= 7.0.0), cdbs, quilt, ruby (>= 1.8.5)
+Build-Depends: debhelper (>= 7.0.0), cdbs, quilt, ruby | ruby-interpreter
 Standards-Version: 3.9.2
 Homepage: http://projects.puppetlabs.com/projects/hiera
 
 Package: hiera
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, ruby (>= 1.8.5), libjson-ruby || ruby-json
+Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter, libjson-ruby | ruby-json
 Description: A simple pluggable Hierarchical Database.
 	Hiera is a simple pluggable Hierarchical Database.

--- a/ext/debian/rules
+++ b/ext/debian/rules
@@ -13,21 +13,22 @@ include /usr/share/cdbs/1/rules/debhelper.mk
 include /usr/share/cdbs/1/rules/patchsys-quilt.mk
 
 BUILD_ROOT=$(DESTDIR)/$(CURDIR)/debian/$(cdbs_curpkg)
-LIBDIR=$(shell /usr/bin/ruby -rrbconfig -e 'puts Config::CONFIG["rubylibdir"]')
+LIBDIR=$(shell /usr/bin/ruby -rrbconfig -e 'puts RbConfig::CONFIG["vendordir"]')
+BIN_DIR=$(shell /usr/bin/ruby -rrbconfig -e 'puts RbConfig::CONFIG["bindir"]')
 RUBYLIB=$(BUILD_ROOT)/$(LIBDIR)
-BIN_DIR=$(BUILD_ROOT)/usr/bin
+RUBYBIN=$(BUILD_ROOT)/$(BIN_DIR)
 DOC_DIR=$(BUILD_ROOT)/usr/share/doc/hiera/
 DATA_DIR=$(BUILD_ROOT)/var/lib/hiera
 
 install/hiera::
 	mkdir -p $(RUBYLIB)
-	mkdir -p $(BIN_DIR)
+	mkdir -p $(RUBYBIN)
 	mkdir -p $(DOC_DIR)
 	mkdir -p $(DATA_DIR)
 	mkdir -p $(BUILD_ROOT)/etc
 	cp -pr  lib/hiera $(RUBYLIB)
 	cp -p lib/hiera.rb $(RUBYLIB)
-	cp -p  bin/* $(BIN_DIR)
+	cp -p  bin/* $(RUBYBIN)
 	cp -pr ext/hiera.yaml $(BUILD_ROOT)/etc
 	cp -p CHANGELOG COPYING README.md $(DOC_DIR)
 


### PR DESCRIPTION
This commit updates hiera dependencies and modifies
it to use vendordir, for a ruby version-independent
install, which will work for older systems that use
1.8, and newer ones with pull in 1.9.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
