### PR TITLE
Only load rubygems in bin/hiera

### DIFF
--- a/bin/hiera
+++ b/bin/hiera
@@ -11,9 +11,11 @@
 #
 # $ hiera release 'rel/%{location}' location=dc2 --yaml some.node.yaml
 
-begin
-  require 'rubygems'
-rescue LoadError
+unless defined? Bundler::Setup
+  begin
+    require 'rubygems'
+  rescue LoadError
+  end
 end
 require 'hiera'
 require 'hiera/util'

--- a/lib/hiera.rb
+++ b/lib/hiera.rb
@@ -1,7 +1,3 @@
-begin
-  require 'rubygems'
-rescue LoadError
-end
 require 'yaml'
 
 class Hiera


### PR DESCRIPTION
We should not require rubygems when used as a library. When invoked from the
command line we require rubygems if bundler has not been loaded. If bundler
has been loaded we assume rubygems is already loaded if it needs to be, as
requiring rubygems after loading bundler can break the bundler setup.
