### PR TITLE
(Maint) Make Hiera operate with /dev/null config file

### DIFF
--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -59,6 +59,18 @@ class Hiera
         Hiera.expects(:logger=).with("console")
         Config.load({})
       end
+
+      context "loading '/dev/null' as spec tests do" do
+        before :each do
+          # Simulate the behavior of YAML.load_file('/dev/null') in MRI 1.9.3p194
+          Config.stubs(:yaml_load_file).
+            raises(TypeError, "no implicit conversion from nil to integer")
+        end
+
+        it "is not exceptional behavior" do
+          expect { Config.load('/dev/null') }.to_not raise_error
+        end
+      end
     end
 
     describe "#load_backends" do


### PR DESCRIPTION
Without this patch applied, some Puppet spec tests cause the following
exceptional behavior:

```
$ rspec -fp spec/unit/parser/functions/hiera_include_spec.rb
Failure/Error: scope.function_hiera_include(['key'])
TypeError: no implicit conversion from nil to integer
# /workspace/puppet-3.x/src/hiera/lib/hiera/config.rb:15:in `load'
# ./lib/hiera_puppet.rb:64:in `hiera_config'
# ./lib/hiera_puppet.rb:57:in `hiera'
# ./lib/hiera_puppet.rb:13:in `lookup'
# ./lib/puppet/parser/functions/hiera_include.rb:5:in `block in <module:Functions>'
# ./lib/puppet/parser/functions.rb:63:in `block in newfunction'
# ./lib/puppet/parser/scope.rb:445:in `method_missing'
```

The root cause of this problem is that the Psych YAML parser can't handle
loading from '/dev/null':

```
$ irb -r yaml
>> YAML.load_file('/dev/null')
TypeError: no implicit conversion from nil to integer
   from /Users/jeff/.rbenv/versions/1.9.3-p194/lib/ruby/1.9.1/psych.rb:297:in `initialize'
   from /Users/jeff/.rbenv/versions/1.9.3-p194/lib/ruby/1.9.1/psych.rb:297:in `open'
   from /Users/jeff/.rbenv/versions/1.9.3-p194/lib/ruby/1.9.1/psych.rb:297:in `load_file'
   from (irb):2
   from /Users/jeff/.rbenv/versions/1.9.3-p194/bin/irb:12:in `<main>'
```

This patch fixes the problem by catching the exception inside of Hiera
and returning `false` instead of raising an exception.  The default
configuration settings are then used instead of causing an unhandled
exception.
