### PR TITLE
(#17087) Fix backend key in hiera.yaml

### DIFF
--- a/ext/hiera.yaml
+++ b/ext/hiera.yaml
@@ -1,5 +1,5 @@
 ---
-:backend:
+:backends:
   - yaml
 :hierarchy:
   - defaults


### PR DESCRIPTION
Previously the hiera.yaml that is laid down in packaged installs used 'backend'
instead of 'backends' which means that hiera falls through to the default yaml
backend, as no 'backends' key exists in the config. This commit fixes the
hiera.yaml file to use 'backends' instead.
