### PR TITLE
(maint) Handle lack of RSpec::Core::RakeTask gracefully

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,8 @@
-require 'rubygems'
-require 'rspec/core/rake_task'
+begin
+  require 'rubygems'
+  require 'rspec/core/rake_task'
+rescue LoadError
+end
 
 Dir['tasks/**/*.rake'].each { |t| load t }
 Dir['ext/packaging/tasks/**/*'].sort.each { |t| load t }
@@ -36,8 +39,10 @@ if File.exist?(build_defs_file)
   end
 end
 
-desc "Run all specs"
-RSpec::Core::RakeTask.new(:test) do |t|
-  t.pattern = 'spec/**/*_spec.rb'
+if defined?(RSpec::Core::RakeTask)
+  desc "Run all specs"
+  RSpec::Core::RakeTask.new(:test) do |t|
+    t.pattern = 'spec/**/*_spec.rb'
+  end
 end
 


### PR DESCRIPTION
Having a hard dependency of RSpec to run rake tasks, specifically packaging
tasks, is unnecessary. This commit rescues any LoadError from loading rubygems
and rspec and also only presents the spec task if RSpec::Core::RakeTask is
defined/loaded.
