### PR TITLE
(#18214) Update gem dependency to json_pure from json

### DIFF
--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -13,5 +13,5 @@ gem_require_path: 'lib'
 gem_test_files: 'spec/**/*'
 gem_executables: 'hiera'
 gem_runtime_dependencies:
-  json:
+  json_pure:
 gem_default_executables: 'hiera'


### PR DESCRIPTION
As the json gem requires ruby-dev, gcc, and other tools to install via
rubygems, this commit changes the dependency to json_pure for gems, which will
lessen the dependencies required for install, as json_pure is pure ruby, with
no compilation required.
