### PR TITLE
(maint) Add Travis CI Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 pkg
 test.rb
 ext/packaging
+Gemfile.lock
+.bundle/
+vendor/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: ruby
+bundler_args: --without development
+script: "bundle exec rake spec SPEC_OPTS='--format documentation'"
+notifications:
+  email: false
+rvm:
+  - 1.9.3
+  - 1.8.7
+  - ruby-head
+matrix:
+  allow_failures:
+    - rvm: ruby-head

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,18 @@
+source :rubygems
+
+group :development do
+  gem 'watchr'
+end
+
+group :development, :test do
+  gem 'rake'
+  gem 'rspec', "~> 2.11.0", :require => false
+  gem 'mocha', "~> 0.10.5", :require => false
+  gem 'json', "~> 1.7", :require => false
+end
+
+if File.exists? "#{__FILE__}.local"
+  eval(File.read("#{__FILE__}.local"), binding)
+end
+
+# vim:ft=ruby

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Hiera
 
+[![Build Status](https://travis-ci.org/puppetlabs/hiera.png?branch=master)](https://travis-ci.org/puppetlabs/hiera)
+
 A simple pluggable Hierarchical Database.
 
 -

--- a/Rakefile
+++ b/Rakefile
@@ -41,8 +41,13 @@ end
 
 if defined?(RSpec::Core::RakeTask)
   desc "Run all specs"
-  RSpec::Core::RakeTask.new(:test) do |t|
+  RSpec::Core::RakeTask.new(:spec) do |t|
     t.pattern = 'spec/**/*_spec.rb'
   end
 end
 
+task :test => :spec
+
+task :default do
+  sh 'rake -T'
+end


### PR DESCRIPTION
Without this patch facter has Travis CI configuration files, but they
don't seem to completely specify the dependency versions and the build
matrix.  This patch addresses the problem by putting the dependency
information in the conventional Gemfile location.

This patch should coincide with enabling Travis CI support for pull
requests.  A build status image is also included in the project README.
Finally, this patch also removes the Gemfile.lock since this shouldn't
be included in the repository as Facter is more of application than it
is a library.  This reverses the decision to include it, which was my
mistake, in 0b49eae and (#15464).
