### PR TITLE
(maint) Add Travis CI support to active branches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 pkg
 test.rb
 ext/packaging
+.bundle/
+vendor/
+Gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: ruby
+bundler_args: --without development
+script: "bundle exec rake spec SPEC_OPTS='--format documentation'"
+notifications:
+  email: false
+rvm:
+  - 1.9.3
+  - 1.8.7
+  - ruby-head
+matrix:
+  allow_failures:
+    - rvm: ruby-head

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,18 @@
+source :rubygems
+
+group :development do
+  gem 'watchr'
+end
+
+group :development, :test do
+  gem 'rake'
+  gem 'rspec', "~> 2.11.0", :require => false
+  gem 'mocha', "~> 0.10.5", :require => false
+  gem 'json', "~> 1.7", :require => false
+end
+
+if File.exists? "#{__FILE__}.local"
+  eval(File.read("#{__FILE__}.local"), binding)
+end
+
+# vim:ft=ruby

--- a/Rakefile
+++ b/Rakefile
@@ -41,8 +41,9 @@ end
 
 if defined?(RSpec::Core::RakeTask)
   desc "Run all specs"
-  RSpec::Core::RakeTask.new(:test) do |t|
+  RSpec::Core::RakeTask.new(:spec) do |t|
     t.pattern = 'spec/**/*_spec.rb'
   end
+  task :test => :spec
 end
 


### PR DESCRIPTION
Without this patch all active branches do not have proper Travis
configuration files.  This is a problem because Travis will exercise any
branch pushed to the puppetlabs organization repository on Github.  The
default behavior is to email notifications which is undesirable.

To address this problem Travis configuration settings are added to an
active branch.

Active branches are those that have recent activity when compared
against the following command:

```
for k in `git branch -r |perl -pe s/^..//`
do
  echo -e `git show --pretty=format:"%Cgreen%ci %Cblue%cr%Creset" $k|head -n 1`\\t$k;
done | sort -r | grep origin
```

Which should produce output like:

```
2013-01-06 00:03:10 -0800 14 hours ago  origin/master
2012-12-27 09:50:20 -0800 10 days ago   origin/1.x
```
