### PR TITLE
Make Yaml Syntax more Yaml like - With Tests :)

### DIFF
--- a/lib/hiera/backend/yaml_backend.rb
+++ b/lib/hiera/backend/yaml_backend.rb
@@ -8,8 +8,32 @@ class Hiera
         @cache = cache || Filecache.new
       end
 
+      # recursive lookup for key/values inside data. This allows
+      # foo::bar, foo::bar::buzz, or even foo::bar::buzz::blam
+      def sub_lookup(data, classname, key, delimiter)
+        if data.has_key? classname then
+          if key.include?(delimiter) then
+            result = sub_lookup(data[classname], key.split(delimiter).first,
+                                key.sub(/^.*?#{delimiter}/,""), delimiter)
+          else
+            return data[classname][key]
+          end
+        else
+          return nil
+        end
+      end
+
       def lookup(key, scope, order_override, resolution_type)
         answer = nil
+
+        # If the hash_delimiter is turned on inside the hiera.yaml
+        # then the user has indicated that they would like the nicer
+        # YAML style of representing key/value pairs. As such, this 
+        # means a bit more additional parsing later on, but not much
+        delimiter = nil
+        if Config[:yaml] and Config[:yaml].has_key? :hash_delimiter then
+          delimiter = Config[:yaml][:hash_delimiter]
+        end
 
         Hiera.debug("Looking up #{key} in YAML backend")
 
@@ -24,20 +48,29 @@ class Hiera
           end
 
           next if data.empty?
-          next unless data.include?(key)
+          # Here is the conditional logic that will introspect keys/values
+          # to find a match. This uses recursion to allow arbitrary depth.
+          if delimiter and key.include? delimiter then
+            result = sub_lookup(data, key.split(delimiter).first,
+                                key.sub(/^.*?#{delimiter}/,""), delimiter)
+            next unless result
+            Hiera.debug("Found #{key} in #{source} inside hash")
+            new_answer = Backend.parse_answer(result, scope)
+          else
+            next unless data.include?(key)
+            # Extra logging that we found the key. This can be outputted
+            # multiple times if the resolution type is array or hash but that
+            # should be expected as the logging will then tell the user ALL the
+            # places where the key is found.
+            Hiera.debug("Found #{key} in #{source}")
+            # for array resolution we just append to the array whatever
+            # we find, we then goes onto the next file and keep adding to
+            # the array
+            #
+            # for priority searches we break after the first found data item
+            new_answer = Backend.parse_answer(data[key], scope)
+          end
 
-          # Extra logging that we found the key. This can be outputted
-          # multiple times if the resolution type is array or hash but that
-          # should be expected as the logging will then tell the user ALL the
-          # places where the key is found.
-          Hiera.debug("Found #{key} in #{source}")
-
-          # for array resolution we just append to the array whatever
-          # we find, we then goes onto the next file and keep adding to
-          # the array
-          #
-          # for priority searches we break after the first found data item
-          new_answer = Backend.parse_answer(data[key], scope)
           case resolution_type
           when :array
             raise Exception, "Hiera type mismatch: expected Array and got #{new_answer.class}" unless new_answer.kind_of? Array or new_answer.kind_of? String

--- a/spec/unit/backend/yaml_backend_spec.rb
+++ b/spec/unit/backend/yaml_backend_spec.rb
@@ -143,6 +143,72 @@ class Hiera
           @backend.lookup("boolval", {}, nil, :priority).should == true
           @backend.lookup("numericval", {}, nil, :priority).should == 1
         end
+
+        it "should introspect hashes if key is in foo::bar syntax" do
+          Config.load({:yaml => {:hash_delimiter => "::"}})
+          Backend.expects(:datasources).multiple_yields(["one"])
+          Backend.expects(:datafile).with(:yaml, {}, "one", "yaml").returns("/nonexisting/one.yaml")
+          File.stubs(:exist?).with("/nonexisting/one.yaml").returns(true)
+
+          @cache.expects(:read).with("/nonexisting/one.yaml", Hash, {}).returns({"foo"=>{"key"=>"answer"}})
+
+          @backend.lookup("foo::key", {}, nil, :priority).should == "answer"
+        end
+
+        it "should introspect hashes if key is in foo::bar::fizz syntax" do
+          Config.load({:yaml => {:hash_delimiter => "::"}})
+          Backend.expects(:datasources).multiple_yields(["one"])
+          Backend.expects(:datafile).with(:yaml, {}, "one", "yaml").returns("/nonexisting/one.yaml")
+          File.stubs(:exist?).with("/nonexisting/one.yaml").returns(true)
+
+          @cache.expects(:read).with("/nonexisting/one.yaml", Hash, {}).returns({"foo"=>{"key"=>{"fizz"=>"answer"}}})
+
+          @backend.lookup("foo::key::fizz", {}, nil, :priority).should == "answer"
+        end
+
+        it "should still return nil if introspecting hashes fails for foo::bar syntax" do
+          Config.load({:yaml => {:hash_delimiter => "::"}})
+          Backend.expects(:datasources).multiple_yields(["one"])
+          Backend.expects(:datafile).with(:yaml, {}, "one", "yaml").returns("/nonexisting/one.yaml")
+          File.stubs(:exist?).with("/nonexisting/one.yaml").returns(true)
+
+          @cache.expects(:read).with("/nonexisting/one.yaml", Hash, {}).returns({"foo"=>{"bar"=>"answer"}})
+
+          @backend.lookup("foo::key", {}, nil, :priority).should be_nil
+        end
+
+        it "should return nil if introspecting hashes is not enabled in Config" do
+          Config.load({})
+          Backend.expects(:datasources).multiple_yields(["one"])
+          Backend.expects(:datafile).with(:yaml, {}, "one", "yaml").returns("/nonexisting/one.yaml")
+          File.stubs(:exist?).with("/nonexisting/one.yaml").returns(true)
+
+          @cache.expects(:read).with("/nonexisting/one.yaml", Hash, {}).returns({"foo"=>{"bar"=>"answer"}})
+
+          @backend.lookup("foo::key", {}, nil, :priority).should be_nil
+        end
+
+        it "should return nil if the delimiter is not in the key" do
+          Config.load({:yaml => {:hash_delimiter => "__"}})
+          Backend.expects(:datasources).multiple_yields(["one"])
+          Backend.expects(:datafile).with(:yaml, {}, "one", "yaml").returns("/nonexisting/one.yaml")
+          File.stubs(:exist?).with("/nonexisting/one.yaml").returns(true)
+
+          @cache.expects(:read).with("/nonexisting/one.yaml", Hash, {}).returns({"foo"=>{"bar"=>"answer"}})
+
+          @backend.lookup("foo::key", {}, nil, :priority).should be_nil
+        end
+
+        it "should return nil if the delimiter is in the key but mismatches" do
+          Config.load({:yaml => {:hash_delimiter => "::"}})
+          Backend.expects(:datasources).multiple_yields(["one"])
+          Backend.expects(:datafile).with(:yaml, {}, "one", "yaml").returns("/nonexisting/one.yaml")
+          File.stubs(:exist?).with("/nonexisting/one.yaml").returns(true)
+
+          @cache.expects(:read).with("/nonexisting/one.yaml", Hash, {}).returns({"foo"=>{"bar"=>"answer"}})
+
+          @backend.lookup("bar::key", {}, nil, :priority).should be_nil
+        end
       end
     end
   end


### PR DESCRIPTION
required key/values to be in this format; nginx::gzip: on

That's great for one off variables, but the syntax really starts
to look very noisy when you get a yaml file with 10 modules,
and each modules has 20 lines in looking like;

```
  nginx::sendfile: on
  nginx::worker_connections: 10
  nginx::gzip: on
  nginx::tcp_nopush: on
```

Instead, it's a lot cleaner/clearer and (I think) in keeping with
the spirit of yaml to have something such as;

```
  nginx:
    worker_connections: 10
    sendfile: on
    tcp_nopush: on
    keepalive_timeout: 0
```

This patch and tests accomplish the latter syntax.
