### PR TITLE
(#18718) Make the puppet logger fail to load if puppet is not loaded

### DIFF
--- a/lib/hiera/puppet_logger.rb
+++ b/lib/hiera/puppet_logger.rb
@@ -1,5 +1,9 @@
 class Hiera
   module Puppet_logger
+    unless defined? Puppet
+      raise Exception, "Puppet is not currently loaded. This logger is only valid when hiera is running within puppet."
+    end
+
     class << self
       def warn(msg)
         Puppet.notice("hiera(): #{msg}")


### PR DESCRIPTION
This makes hiera fall back to the console logger
