### PR TITLE
(#17094) Escape variable name in parse_string

### DIFF
--- a/lib/hiera/backend.rb
+++ b/lib/hiera/backend.rb
@@ -95,7 +95,7 @@ class Hiera
                 val = extra_data[var]
             end
 
-            tdata.gsub!(/%\{#{var}\}/, val)
+            tdata.gsub!(/%\{#{Regexp.escape(var)}\}/, val)
           end
         end
 

--- a/spec/unit/backend_spec.rb
+++ b/spec/unit/backend_spec.rb
@@ -127,6 +127,11 @@ class Hiera
         Backend.parse_string(input, {"rspec" => :undefined}, {"rspec" => "test"}).should == "test_test_test"
       end
 
+      it "should escape the variable name for regexes" do
+        input = "test_%{.*}_test}"
+        Backend.parse_string(input, {".*" => "test"}).should == "test_test_test}"
+      end
+
     end
 
     describe "#parse_answer" do


### PR DESCRIPTION
Without this, parse_string would break (usually with an infinite loop) if a variable name had characters that were significant in a regular expression.
