### PR TITLE
(#17434) Do not fall back to different lookups

### DIFF
--- a/lib/hiera/recursive_lookup.rb
+++ b/lib/hiera/recursive_lookup.rb
@@ -1,0 +1,31 @@
+# Allow for safe recursive lookup of values during variable interpolation.
+#
+# @api private
+class Hiera::RecursiveLookup
+  def initialize(scope, extra_data)
+    @seen = []
+    @scope = scope
+    @extra_data = extra_data
+  end
+
+  def lookup(name, &block)
+    if @seen.include?(name)
+      raise Exception, "Interpolation loop detected in [#{@seen.join(', ')}]"
+    end
+    @seen.push(name)
+    ret = yield(current_value)
+    @seen.pop
+    ret
+  end
+
+  def current_value
+    name = @seen.last
+
+    scope_val = @scope[name]
+    if scope_val.nil? || scope_val == :undefined
+      @extra_data[name]
+    else
+      scope_val
+    end
+  end
+end

--- a/spec/unit/backend_spec.rb
+++ b/spec/unit/backend_spec.rb
@@ -175,6 +175,14 @@ class Hiera
         input = "test_%{rspec}_test"
         Backend.parse_string(input, scope).should == "test_final_test"
       end
+
+      it "raises an error if the recursive lookup results in an infinite loop" do
+        scope = {"first" => "%{second}", "second" => "%{first}"}
+        input = "test_%{first}_test"
+        expect do
+          Backend.parse_string(input, scope)
+        end.to raise_error Exception, "Interpolation loop detected in [first, second]"
+      end
     end
 
     describe "#parse_answer" do


### PR DESCRIPTION
The changes made in GH-29 (commit 3ec4165) caused a sequence of unwanted
lookups to occur. It was originally conceived as a way to get rid of
deprecation warnings that puppet was issuing (incorrectly issuing) when
looking up facts without preceeding the lookup with ::. The change,
however, also had the effect that if a variable contained :: and did not
exist, then hiera would end up in an infinite loop trying to resolve the
interpolation.

This adds tests to assert that we don't try to do that kind of "smart"
lookup by trying to clarify that the lookup is simply on exactly what is
contained inside the %{} inside the string.

This closes GH-114
