### PR TITLE
(maint) Remove natty from build_defaults, changelog

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -2,7 +2,7 @@
 packaging_url: 'git://github.com/puppetlabs/packaging.git --branch=master'
 packaging_repo: 'packaging'
 default_cow: 'base-squeeze-i386.cow'
-cows: 'base-lucid-i386.cow base-natty-i386.cow base-oneiric-i386.cow base-precise-i386.cow base-quantal-i386.cow base-sid-i386.cow base-squeeze-i386.cow base-stable-i386.cow base-testing-i386.cow base-unstable-i386.cow base-wheezy-i386.cow'
+cows: 'base-lucid-i386.cow base-oneiric-i386.cow base-precise-i386.cow base-quantal-i386.cow base-sid-i386.cow base-squeeze-i386.cow base-stable-i386.cow base-testing-i386.cow base-unstable-i386.cow base-wheezy-i386.cow'
 pbuild_conf: '/etc/pbuilderrc'
 packager: 'puppetlabs'
 gpg_name: 'info@puppetlabs.com'

--- a/ext/debian/changelog.erb
+++ b/ext/debian/changelog.erb
@@ -1,4 +1,4 @@
-hiera (<%= @debversion %>) lucid maverick natty lenny squeeze precise wheezy sid unstable; urgency=low
+hiera (<%= @debversion %>) lucid squeeze precise quantal wheezy sid unstable; urgency=low
 
   * update to version <%= @debversion %>
 


### PR DESCRIPTION
Ubuntu's Natty has been EOL for 3 months
[http://en.wikipedia.org/wiki/List_of_Ubuntu_releases#Ubuntu_11.04_.28Natty_Narwhal.29],
so this commit removes the natty cow from build_defaults and also removes natty
from the changelog template. It also adds quantal, which had been previously
neglected, to the changelog template.
