### PR TITLE
Interpolate hash keys like already done for strings.

### DIFF
--- a/lib/hiera/backend.rb
+++ b/lib/hiera/backend.rb
@@ -116,7 +116,9 @@ class Hiera
         elsif data.is_a?(Hash)
           answer = {}
           data.each_pair do |key, val|
-            answer[key] = parse_answer(val, scope, extra_data)
+            dupkey = key.dup
+            interpolated_key = parse_string(dupkey, scope, extra_data)
+            answer[interpolated_key] = parse_answer(val, scope, extra_data)
           end
 
           return answer


### PR DESCRIPTION
The needs for this appeared while using create_resources(), which
expects a hash, and takes hash keys as resources titles.
When using hiera, hash keys where not interpolated before this
patch.

You can now write this into hiera and have %{hostname} properly replaced by its facter value:

```
bacula::job:
    %{hostname}_Cyrus:
        fileset: MailServer
        bacula_schedule: 'CycleStandard'
    %{hostname}_LDAP:
        fileset: LDAP
        bacula_schedule: 'CycleStandard'
```
