### PR TITLE
Fix #19792 - cryptic error when missing deep_merge gem

### DIFF
--- a/lib/hiera/config.rb
+++ b/lib/hiera/config.rb
@@ -42,8 +42,23 @@ class Hiera::Config
         @config[:logger] = "console"
         Hiera.logger = "console"
       end
+    
+      self.validate!
 
       @config
+    end
+
+    def validate!
+      case @config[:merge_behavior]
+      when :deep,'deep',:deeper,'deeper'
+        begin
+          require "deep_merge"
+        rescue LoadError
+          Hiera.warn "Ignoring configured merge_behavior"
+          Hiera.warn "Must have 'deep_merge' gem installed."
+          @config[:merge_behavior] = :native
+        end
+      end
     end
 
     ##

--- a/spec/unit/backend_spec.rb
+++ b/spec/unit/backend_spec.rb
@@ -390,6 +390,7 @@ class Hiera
       before do
         Hiera.stubs(:debug)
         Hiera.stubs(:warn)
+        Config.stubs(:validate!)
       end
 
       it "uses Hash.merge when configured with :merge_behavior => :native" do


### PR DESCRIPTION
The configuration loader will try to pre-emptively load 'deep_merge' if
the 'deep' or 'deeper' options were given to :merge_behavior.

If the load fails, it will warn the user and revert back to 'native'.

```
WARN: Tue Mar 26 18:02:33 -0400 2013: Ignoring configured merge_behavior
WARN: Tue Mar 26 18:02:33 -0400 2013: Must have 'deep_merge' gem installed.
```
