### PR TITLE
(#20137) Test for Puppet robustly

### DIFF
--- a/lib/hiera/puppet_logger.rb
+++ b/lib/hiera/puppet_logger.rb
@@ -2,7 +2,7 @@ class Hiera
   module Puppet_logger
     class << self
       def suitable?
-        Kernel.const_defined?(:Puppet)
+        defined?(::Puppet) == "constant"
       end
 
       def warn(msg)


### PR DESCRIPTION
The test for puppet being present didn't seem to work when used in Rack 
setups. I don't know why it didn't work there, however. This changes to using
"defined?" which is used in other parts of the puppet codebase and appears to
work in the way expected in Rack.
