### PR TITLE
Initial addition of Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+#!/usr/bin/make -f
+
+NAME=hiera
+RUBY=ruby
+SYSCONFDIR=$(DESTDIR)/etc
+LIBDIR=$(shell $(RUBY) -rrbconfig -e 'puts RbConfig::CONFIG["sitelibdir"]')
+RUBYBINDIR=$(shell $(RUBY) -rrbconfig -e 'puts RbConfig::CONFIG["bindir"]')
+DOCDIR=$(DESTDIR)/usr/share/doc/$(NAME)
+
+all:
+
+install::
+	mkdir -p $(LIBDIR)
+	mkdir -p $(RUBYBINDIR)
+	mkdir -p $(DOCDIR)
+	mkdir -p $(SYSCONFDIR)
+	cp -pr lib/hiera $(LIBDIR)
+	cp -p lib/hiera.rb $(LIBDIR)
+	cp -p bin/* $(RUBYBINDIR)
+	cp -pr ext/hiera.yaml $(SYSCONFDIR)
+	cp -p COPYING README.md $(DOCDIR)
+
+clean::


### PR DESCRIPTION
This commit adds a rudimentary Makefile for installing hiera. This will allow
us to simplify the deb and rpm packaging, to just use the Makefile. This will
also help us on the PE side by enabling us to ship hiera as a library, like we
do in FOSS.
