### PR TITLE
Require rubygems for install.rb on windows

### DIFF
--- a/install.rb
+++ b/install.rb
@@ -144,6 +144,7 @@ def prepare_installation
     configdir = InstallOptions.configdir
   elsif is_windows?
     begin
+      require 'rubygems'
       require 'win32/dir'
     rescue LoadError => e
       puts "Cannot run on Microsoft Windows without the sys-admin, win32-process, win32-dir & win32-service gems: #{e}"


### PR DESCRIPTION
Without requiring rubygems, ruby will fail to find the win32/dir on a Windows
install of hiera (at least on ruby 1.8). This commit adds the require on
rubygems to install.rb, only on Windows platforms.
