### PR TITLE
Update example hiera.yaml for Psych parser

### DIFF
--- a/ext/hiera.yaml
+++ b/ext/hiera.yaml
@@ -3,8 +3,8 @@
   - yaml
 :hierarchy:
   - defaults
-  - %{clientcert}
-  - %{environment}
+  - "%{clientcert}"
+  - "%{environment}"
   - global
 
 :yaml:


### PR DESCRIPTION
Bare %{clientcert} in yaml is invalid, and the Psych parser will not load such
a file. The Syck parser happily accepted such files. The solution is to quote
the %{clientcert} so it becomes "%{clientcert}" and Psych recognized it as a
string. Relevant part of the YAML spec: http://yaml.org/spec/current.html#%
directive/
