### PR TITLE
Added a flag "precedence" which can be either "backend" or "hierarchy".

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,49 @@ Hiera can search through all the tiers in a hierarchy and merge the result into 
 array.  This is used in the hiera-puppet project to replace External Node Classifiers by
 creating a Hiera compatible include function.
 
+### Precedence
+
+By default Hiera searches through the hierarchy for one entire hierarchy at a time
+before moving on to the next one. This precedence is called "backend". There is
+also a precedence called "hierarchy", where hiera will search through all backends
+in order for each tier of the hierarchy.
+
+<pre>
+For example, let's say in your hiera.yaml you have:
+---
+:backends:
+  - yaml
+  - json
+:hierarchy:
+  - tier/%{clientcert}
+  - common
+:precedence: hierarchy
+
+with files:
+tier/a.json
+{
+    "somefact": "value"
+}
+
+and common.yaml
+---
+somefact: this
+
+If you're looking for somefact with this set up, hiera will look for the following files:
+tier/a.yaml
+tier/a.json
+common.yaml
+common.json
+</pre>
+
+So the value of "somefact" would be "value" for clientcert a, but "this" for everyone else,
+even though yaml gets searched first. Using the traditional "backend" precedence, the value
+of "somefact" for node a would be "this" because yaml would get searched all the way down
+the hierarchy before json ever got touched.
+
+Be careful: not all backends work well with this option. Some development may be required
+in order to make sure a backend respects the hierarchy.
+
 ## Future Enhancements
 
  * More backends should be created
@@ -113,6 +156,8 @@ A sample configuration file can be seen here:
 :backends:
   - yaml
   - puppet
+
+:precedence: backend
 
 :logger: console
 

--- a/bin/hiera
+++ b/bin/hiera
@@ -27,12 +27,13 @@ require 'optparse'
 require 'pp'
 
 options = {
-  :default => nil,
-  :config  => File.join(Hiera::Util.config_dir, 'hiera.yaml'),
-  :scope   => {},
-  :key     => nil,
-  :verbose => false,
-  :resolution_type => :priority
+  :default         => nil,
+  :config          => File.join(Hiera::Util.config_dir, 'hiera.yaml'),
+  :scope           => {},
+  :key             => nil,
+  :verbose         => false,
+  :resolution_type => :priority,
+  :precedence      => nil,
 }
 
 # Loads the scope from YAML or JSON files
@@ -133,6 +134,18 @@ OptionParser.new do |opts|
     options[:resolution_type] = :hash
   end
 
+  # Most likely the user didn't enter a symbol; convert to a symbol
+  opts.on("--precedence PRECEDENCE", "-p", "Specify precedence") do |v|
+    if v =~ /^:?[hH]/
+      options[:precedence] = :hierarchy
+    elsif v =~ /^:?[bB]/i
+      options[:precedence] = :backend
+    else
+      STDERR.puts "Precedence can only be one of either hierarchy or backend"
+      exit
+    end
+  end
+
   opts.on("--config CONFIG", "-c", "Configuration file") do |v|
     if File.exist?(v)
       options[:config] = v
@@ -218,7 +231,7 @@ unless options[:verbose]
   Hiera.logger = "noop"
 end
 
-ans = hiera.lookup(options[:key], options[:default], options[:scope], nil, options[:resolution_type])
+ans = hiera.lookup(options[:key], options[:default], options[:scope], options[:precedence], nil, options[:resolution_type])
 
 if ans.is_a?(String)
   puts ans

--- a/lib/hiera/backend.rb
+++ b/lib/hiera/backend.rb
@@ -62,6 +62,7 @@ class Hiera
         end
 
         hierarchy.insert(0, override) if override
+        hierarchy = [hierarchy.at(0)] if override and Config[:precedence].equal? :hierarchy
 
         hierarchy.flatten.map do |source|
           source = parse_string(source, scope)

--- a/lib/hiera/config.rb
+++ b/lib/hiera/config.rb
@@ -12,7 +12,8 @@ class Hiera::Config
     def load(source)
       @config = {:backends => "yaml",
                  :hierarchy => "common",
-                 :merge_behavior => :native }
+                 :merge_behavior => :native,
+                 :precedence => :backend }
 
       if source.is_a?(String)
         if File.exist?(source)
@@ -32,6 +33,14 @@ class Hiera::Config
         end
       elsif source.is_a?(Hash)
         @config.merge! source
+      end
+
+      # Be friendly: Do a little message to allow strings instead of symbols
+      case @config[:precedence]
+        when 'hierarchy'
+          @config[:precedence] = :hierarchy
+        when 'backend'
+          @config[:precedence] = :backend
       end
 
       @config[:backends] = [ @config[:backends] ].flatten

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -8,7 +8,8 @@ class Hiera
           :backends  => ["yaml"],
           :hierarchy => "common",
           :logger    => "console",
-          :merge_behavior=>:native
+          :merge_behavior=>:native,
+          :precedence => :backend
         }
       end
 
@@ -44,11 +45,11 @@ class Hiera
 
       it "should merge defaults with the loaded or supplied config" do
         config = Config.load({})
-        config.should == {:backends => ["yaml"], :hierarchy => "common", :logger => "console", :merge_behavior=>:native}
+        config.should == {:backends => ["yaml"], :precedence => :backend, :hierarchy => "common", :logger => "console", :merge_behavior=>:native}
       end
 
       it "should force :backends to be a flattened array" do
-        Config.load({:backends => [["foo", ["bar"]]]}).should == {:backends => ["foo", "bar"], :hierarchy => "common", :logger => "console", :merge_behavior=>:native}
+        Config.load({:backends => [["foo", ["bar"]]]}).should == {:backends => ["foo", "bar"], :precedence => :backend, :hierarchy => "common", :logger => "console", :merge_behavior=>:native}
       end
 
       it "should load the supplied logger" do

--- a/spec/unit/hiera_spec.rb
+++ b/spec/unit/hiera_spec.rb
@@ -75,7 +75,7 @@ describe "Hiera" do
       Hiera::Config.stubs(:load)
       Hiera::Config.stubs(:load_backends)
       Hiera::Backend.expects(:lookup).with(:key, :default, :scope, :order_override, :resolution_type)
-      Hiera.new.lookup(:key, :default, :scope, :order_override, :resolution_type)
+      Hiera.new.lookup(:key, :default, :scope, :precedence, :order_override, :resolution_type)
     end
   end
 end


### PR DESCRIPTION
It defaults to "backend" which is the traditional way hiera currently works.

Setting "precedence" to "hierarchy" means that all backends will be queried
for a given tier of the hierarchy before moving on to the next tier, in the
order of the backends given in hiera.yaml.
