### PR TITLE
(Bug #22166) rm hardcoded hostname dependencies

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -12,11 +12,12 @@ sign_tar: FALSE
 final_mocks: 'pl-el-5-i386 pl-el-6-i386 pl-fedora-17-i386 pl-fedora-18-i386 pl-fedora-19-i386'
 build_gem: TRUE
 build_dmg: TRUE
-yum_host: 'burji.puppetlabs.com'
+yum_host: 'yum.puppetlabs.com'
 yum_repo_path: '/opt/repository/yum/'
-apt_host: 'burji.puppetlabs.com'
+apt_host: 'apt.puppetlabs.com'
 apt_repo_url: 'http://apt.puppetlabs.com'
 apt_repo_path: '/opt/repository/incoming'
 ips_repo: '/var/pkgrepo'
 ips_store: '/opt/repository'
 ips_host: 'solaris-11-ips-repo.acctest.dc1.puppetlabs.net'
+tar_host: 'downloads.puppetlabs.com'


### PR DESCRIPTION
Prior to this, we had hardcoded burji.puppetlabs.com into
build_defaults.yaml. Since this isn't particularly elegant, this commit
takes that out, and instead uses cnames that point to the right place,
be it burji, or something newer (like burji2)
