### PR TITLE
(#17094) Ensure that a leading $ resolves

### DIFF
--- a/spec/unit/backend_spec.rb
+++ b/spec/unit/backend_spec.rb
@@ -170,6 +170,11 @@ class Hiera
         Backend.parse_string(input, {"data" => "value"}).should == "test__test"
       end
 
+      it "does not try removing unknown, preceeding characters when looking up values" do
+        input = "test_%{$var}_test"
+        Backend.parse_string(input, {"$var" => "value"}).should == "test_value_test"
+      end
+
       it "looks up recursively" do
         scope = {"rspec" => "%{first}", "first" => "%{last}", "last" => "final"}
         input = "test_%{rspec}_test"


### PR DESCRIPTION
The issue was the we could end up in a recursive, infinite loop if the 
variable was preceeded by a `$`. This was caused by an old parsing mechanism
that dumbly stripped off characters and sometimes made no progress. The new
system doesn't do that, but this ensures that it doesn't.
