### PR TITLE
(#22142) Ensure that :datadir is a String

### DIFF
--- a/lib/hiera.rb
+++ b/lib/hiera.rb
@@ -1,6 +1,7 @@
 require 'yaml'
 
 class Hiera
+  require "hiera/error"
   require "hiera/version"
   require "hiera/config"
   require "hiera/util"

--- a/lib/hiera/backend.rb
+++ b/lib/hiera/backend.rb
@@ -16,13 +16,19 @@ class Hiera
       # subject to variable expansion based on scope
       def datadir(backend, scope)
         backend = backend.to_sym
-        default = Hiera::Util.var_dir
 
-        if Config.include?(backend) && !Config[backend].nil?
-          parse_string(Config[backend][:datadir] || default, scope)
+        if Config[backend] && Config[backend][:datadir]
+          dir = Config[backend][:datadir]
         else
-          parse_string(default, scope)
+          dir = Hiera::Util.var_dir
         end
+
+        if !dir.is_a?(String)
+          raise(Hiera::InvalidConfigurationError,
+                "datadir for #{backend} cannot be an array")
+        end
+
+        parse_string(dir, scope)
       end
 
       # Finds the path to a datafile based on the Backend#datadir

--- a/lib/hiera/error.rb
+++ b/lib/hiera/error.rb
@@ -1,0 +1,4 @@
+class Hiera
+  class Error < StandardError; end
+  class InvalidConfigurationError < Error; end
+end

--- a/spec/unit/backend_spec.rb
+++ b/spec/unit/backend_spec.rb
@@ -18,6 +18,17 @@ class Hiera
 
         Config.load({:rspec => nil})
         Backend.datadir(:rspec, {}).should == Hiera::Util.var_dir
+
+        Config.load({:rspec => {}})
+        Backend.datadir(:rspec, {}).should == Hiera::Util.var_dir
+      end
+
+      it "fails when the datadir is an array" do
+        Config.load({:rspec => {:datadir => []}})
+
+        expect do
+          Backend.datadir(:rspec, {})
+        end.to raise_error(Hiera::InvalidConfigurationError, /datadir for rspec cannot be an array/)
       end
     end
 


### PR DESCRIPTION
The previous behavior of the datadir configuration for some backends
allowed it to be an array, but didn't truly handle that case. It worked
because File.join flattens arrays before joining with the file separator.
However the interpolation of variables was not done on array contents.
This lead to users thinking that the datadir was going to be interpolated,
when in fact it wasn't. Instead of trying to cater for these misconfigured
hiera setups, we now raise an error explaining the problem.
