### PR TITLE
(22329) Only delete hiera files in the preflight

### DIFF
--- a/ext/osx/preflight.erb
+++ b/ext/osx/preflight.erb
@@ -16,16 +16,16 @@
 # remove ruby library files
 <%- Dir.chdir("lib") do -%>
   <%- [@apple_old_libdir, @apple_libdir].compact.each do |libdir| -%>
-    <%- Dir.glob("*").each do |file| -%>
-/bin/rm -Rf "${3}<%= libdir %>/<%= file %>"
+    <%- Dir["**/*"].select{ |i| File.file?(i) }.each do |file| -%>
+/bin/rm -f "${3}<%= libdir %>/<%= file %>"
     <%- end -%>
   <%- end -%>
 <%- end -%>
 
 # remove bin files
 <%- Dir.chdir("bin") do -%>
-    <%- Dir.glob("*").each do |file| -%>
-/bin/rm -Rf "${3}<%= @apple_bindir %>/<%= file %>"
+    <%- Dir["**/*"].select{ |i| File.file?(i) }.each do |file| -%>
+/bin/rm -f "${3}<%= @apple_bindir %>/<%= file %>"
   <%- end -%>
 <%- end -%>
 


### PR DESCRIPTION
Previously, the OSX preflight removed the contents of that ‘hiera’ directory,
which also happens to be where the puppet.pkg places the contents of
hiera_puppet. The fix is simple – from the hiera dir, only remove the files
that exist in the ‘hiera’ project, not those in puppet. This commit
accomplishes this by only deleting files, not the directories. It's a bit
crufty, but its better than clobbering the wrong files.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
