### PR TITLE
(#21211) Improve error message when hiera fails to load YAML file

### DIFF
--- a/lib/hiera/filecache.rb
+++ b/lib/hiera/filecache.rb
@@ -32,8 +32,13 @@ class Hiera
           begin
             @cache[path][:data] = yield(File.read(path))
           rescue => e
-            Hiera.debug("Reading data from %s failed: %s: %s" % [path, e.class, e.to_s])
-            @cache[path][:data] = default
+            error = "Reading data from %s failed: %s: %s" % [path, e.class, e.to_s]
+            if default.nil?
+              raise e.class, error, e.backtrace
+            else
+              Hiera.debug(error)
+              @cache[path][:data] = default
+            end
           end
         else
           @cache[path][:data] = File.read(path)


### PR DESCRIPTION
Avoid errors like this when running puppet:

```
Error: Could not retrieve catalog from remote server: Error 400 on
SERVER: Failed when searching for node
buildagent.drewc.cloud.spotify.net: malformed format string - %S
Warning: Not using cache on failed catalog
Error: Could not retrieve catalog; skipping run
```
