### PR TITLE
(#22777) Propagate errors from cached files

### DIFF
--- a/lib/hiera/backend/json_backend.rb
+++ b/lib/hiera/backend/json_backend.rb
@@ -21,7 +21,7 @@ class Hiera
 
           next unless File.exist?(jsonfile)
 
-          data = @cache.read(jsonfile, Hash, {}) do |data|
+          data = @cache.read_file(jsonfile, Hash) do |data|
             JSON.parse(data)
           end
 

--- a/lib/hiera/backend/yaml_backend.rb
+++ b/lib/hiera/backend/yaml_backend.rb
@@ -19,7 +19,7 @@ class Hiera
 
           next unless File.exist?(yamlfile)
 
-          data = @cache.read(yamlfile, Hash, {}) do |data|
+          data = @cache.read_file(yamlfile, Hash) do |data|
             YAML.load(data)
           end
 

--- a/lib/hiera/filecache.rb
+++ b/lib/hiera/filecache.rb
@@ -24,36 +24,43 @@ class Hiera
     # reading/parsing fails it will return {} instead
     #
     # Prior to calling this method you should be sure the file exist
-    def read(path, expected_type=nil, default=nil)
-      @cache[path] ||= {:data => nil, :meta => path_metadata(path)}
-
-      if File.exist?(path) && !@cache[path][:data] || stale?(path)
-        if block_given?
-          begin
-            @cache[path][:data] = yield(File.read(path))
-          rescue => e
-            error = "Reading data from %s failed: %s: %s" % [path, e.class, e.to_s]
-            if default.nil?
-              raise e.class, error, e.backtrace
-            else
-              Hiera.debug(error)
-              @cache[path][:data] = default
-            end
-          end
-        else
-          @cache[path][:data] = File.read(path)
-        end
+    def read(path, expected_type = Object, default=nil, &block)
+      read_file(path, expected_type, &block)
+    rescue TypeError => detail
+      Hiera.debug("#{detail.message}, setting defaults")
+      @cache[path][:data] = default
+    rescue => detail
+      error = "Reading data from #{path} failed: #{detail.class}: #{detail}"
+      if default.nil?
+        raise detail
+      else
+        Hiera.debug(error)
+        @cache[path][:data] = default
       end
+    end
 
-      if block_given? && !expected_type.nil?
-        unless @cache[path][:data].is_a?(expected_type)
-          Hiera.debug("Data retrieved from %s is not a %s, setting defaults" % [path, expected_type])
-          @cache[path][:data] = default
+    # Read a file when it changes. If a file is re-read and has not changed since the last time
+    # then the last, processed, contents will be returned.
+    #
+    # The processed data can also be checked against an expected type. If the
+    # type does not match a TypeError is raised.
+    #
+    # No error handling is done inside this method. Any failed reads or errors
+    # in processing will be propagated to the caller
+    def read_file(path, expected_type = Object)
+      if stale?(path)
+        data = File.read(path)
+        @cache[path][:data] = block_given? ? yield(data) : data
+
+        if !@cache[path][:data].is_a?(expected_type)
+          raise TypeError, "Data retrieved from #{path} is #{data.class} not #{expected_type}"
         end
       end
 
       @cache[path][:data]
     end
+
+    private
 
     def stale?(path)
       meta = path_metadata(path)

--- a/spec/unit/backend/json_backend_spec.rb
+++ b/spec/unit/backend/json_backend_spec.rb
@@ -33,7 +33,7 @@ class Hiera
           Backend.expects(:datafile).with(:json, {}, "one", "json").returns("/nonexisting/one.json").times(3)
           File.stubs(:exist?).with("/nonexisting/one.json").returns(true)
 
-          @cache.expects(:read).with("/nonexisting/one.json", Hash, {}).returns({"stringval" => "string", "boolval" => true, "numericval" => 1}).times(3)
+          @cache.expects(:read_file).with("/nonexisting/one.json", Hash).returns({"stringval" => "string", "boolval" => true, "numericval" => 1}).times(3)
 
           @backend.lookup("stringval", {}, nil, :priority).should == "string"
           @backend.lookup("boolval", {}, nil, :priority).should == true
@@ -47,7 +47,7 @@ class Hiera
           Backend.expects(:datafile).with(:json, scope, "two", "json").never
 
           File.stubs(:exist?).with("/nonexisting/one.json").returns(true)
-          @cache.expects(:read).with("/nonexisting/one.json", Hash, {}).returns({"key" => "test_%{rspec}"})
+          @cache.expects(:read_file).with("/nonexisting/one.json", Hash).returns({"key" => "test_%{rspec}"})
 
           @backend.lookup("key", scope, nil, :priority).should == "test_test"
         end
@@ -63,8 +63,8 @@ class Hiera
           File.expects(:exist?).with("/nonexisting/one.json").returns(true)
           File.expects(:exist?).with("/nonexisting/two.json").returns(true)
 
-          @cache.expects(:read).with("/nonexisting/one.json", Hash, {}).returns({"key" => "answer"})
-          @cache.expects(:read).with("/nonexisting/two.json", Hash, {}).returns({"key" => "answer"})
+          @cache.expects(:read_file).with("/nonexisting/one.json", Hash).returns({"key" => "answer"})
+          @cache.expects(:read_file).with("/nonexisting/two.json", Hash).returns({"key" => "answer"})
 
           @backend.lookup("key", {}, nil, :array).should == ["answer", "answer"]
         end
@@ -75,7 +75,7 @@ class Hiera
           Backend.expects(:datafile).with(:json, {"rspec" => "test"}, "one", "json").returns("/nonexisting/one.json")
 
           File.expects(:exist?).with("/nonexisting/one.json").returns(true)
-          @cache.expects(:read).with("/nonexisting/one.json", Hash, {}).returns({"key" => "test_%{rspec}"})
+          @cache.expects(:read_file).with("/nonexisting/one.json", Hash).returns({"key" => "test_%{rspec}"})
 
           @backend.lookup("key", {"rspec" => "test"}, nil, :priority).should == "test_test"
         end

--- a/spec/unit/backend/yaml_backend_spec.rb
+++ b/spec/unit/backend/yaml_backend_spec.rb
@@ -32,7 +32,7 @@ class Hiera
           Backend.expects(:datasources).multiple_yields(["one"], ["two"])
           Backend.expects(:datafile).with(:yaml, {}, "one", "yaml").returns("/nonexisting/one.yaml")
           Backend.expects(:datafile).with(:yaml, {}, "two", "yaml").returns(nil).never
-          @cache.expects(:read).with("/nonexisting/one.yaml", Hash, {}).returns({"key"=>"answer"})
+          @cache.expects(:read_file).with("/nonexisting/one.yaml", Hash).returns({"key"=>"answer"})
           File.stubs(:exist?).with("/nonexisting/one.yaml").returns(true)
 
           @backend.lookup("key", {}, nil, :priority).should == "answer"
@@ -50,7 +50,7 @@ class Hiera
           Backend.expects(:datasources).multiple_yields(["one"])
           Backend.expects(:datafile).with(:yaml, {}, "one", "yaml").returns("/nonexisting/one.yaml")
           File.stubs(:exist?).with("/nonexisting/one.yaml").returns(true)
-          @cache.expects(:read).with("/nonexisting/one.yaml", Hash, {}).returns({})
+          @cache.expects(:read_file).with("/nonexisting/one.yaml", Hash).returns({})
 
           @backend.lookup("key", {}, nil, :priority).should be_nil
         end
@@ -62,8 +62,8 @@ class Hiera
           File.stubs(:exist?).with("/nonexisting/one.yaml").returns(true)
           File.stubs(:exist?).with("/nonexisting/two.yaml").returns(true)
 
-          @cache.expects(:read).with("/nonexisting/one.yaml", Hash, {}).returns({"key"=>"answer"})
-          @cache.expects(:read).with("/nonexisting/two.yaml", Hash, {}).returns({"key"=>"answer"})
+          @cache.expects(:read_file).with("/nonexisting/one.yaml", Hash).returns({"key"=>"answer"})
+          @cache.expects(:read_file).with("/nonexisting/two.yaml", Hash).returns({"key"=>"answer"})
 
           @backend.lookup("key", {}, nil, :array).should == ["answer", "answer"]
         end
@@ -75,8 +75,8 @@ class Hiera
           File.stubs(:exist?).with("/nonexisting/one.yaml").returns(true)
           File.stubs(:exist?).with("/nonexisting/two.yaml").returns(true)
 
-          @cache.expects(:read).with("/nonexisting/one.yaml", Hash, {}).returns({})
-          @cache.expects(:read).with("/nonexisting/two.yaml", Hash, {}).returns({"key"=>{"a"=>"answer"}})
+          @cache.expects(:read_file).with("/nonexisting/one.yaml", Hash).returns({})
+          @cache.expects(:read_file).with("/nonexisting/two.yaml", Hash).returns({"key"=>{"a"=>"answer"}})
 
           @backend.lookup("key", {}, nil, :hash).should == {"a" => "answer"}
         end
@@ -88,8 +88,8 @@ class Hiera
           File.stubs(:exist?).with("/nonexisting/one.yaml").returns(true)
           File.stubs(:exist?).with("/nonexisting/two.yaml").returns(true)
 
-          @cache.expects(:read).with("/nonexisting/one.yaml", Hash, {}).returns({"key"=>{"a"=>"answer"}})
-          @cache.expects(:read).with("/nonexisting/two.yaml", Hash, {}).returns({"key"=>{"b"=>"answer", "a"=>"wrong"}})
+          @cache.expects(:read_file).with("/nonexisting/one.yaml", Hash).returns({"key"=>{"a"=>"answer"}})
+          @cache.expects(:read_file).with("/nonexisting/two.yaml", Hash).returns({"key"=>{"b"=>"answer", "a"=>"wrong"}})
 
           @backend.lookup("key", {}, nil, :hash).should == {"a" => "answer", "b" => "answer"}
         end
@@ -101,8 +101,8 @@ class Hiera
           File.stubs(:exist?).with("/nonexisting/one.yaml").returns(true)
           File.stubs(:exist?).with("/nonexisting/two.yaml").returns(true)
 
-          @cache.expects(:read).with("/nonexisting/one.yaml", Hash, {}).returns({"key"=>["a", "answer"]})
-          @cache.expects(:read).with("/nonexisting/two.yaml", Hash, {}).returns({"key"=>{"a"=>"answer"}})
+          @cache.expects(:read_file).with("/nonexisting/one.yaml", Hash).returns({"key"=>["a", "answer"]})
+          @cache.expects(:read_file).with("/nonexisting/two.yaml", Hash).returns({"key"=>{"a"=>"answer"}})
 
           expect {@backend.lookup("key", {}, nil, :array)}.to raise_error(Exception, "Hiera type mismatch: expected Array and got Hash")
         end
@@ -114,8 +114,8 @@ class Hiera
           File.stubs(:exist?).with("/nonexisting/one.yaml").returns(true)
           File.stubs(:exist?).with("/nonexisting/two.yaml").returns(true)
 
-          @cache.expects(:read).with("/nonexisting/one.yaml", Hash, {}).returns({"key"=>{"a"=>"answer"}})
-          @cache.expects(:read).with("/nonexisting/two.yaml", Hash, {}).returns({"key"=>["a", "wrong"]})
+          @cache.expects(:read_file).with("/nonexisting/one.yaml", Hash).returns({"key"=>{"a"=>"answer"}})
+          @cache.expects(:read_file).with("/nonexisting/two.yaml", Hash).returns({"key"=>["a", "wrong"]})
 
           expect { @backend.lookup("key", {}, nil, :hash) }.to raise_error(Exception, "Hiera type mismatch: expected Hash and got Array")
         end
@@ -125,7 +125,7 @@ class Hiera
           Backend.expects(:datafile).with(:yaml, {"rspec" => "test"}, "one", "yaml").returns("/nonexisting/one.yaml")
           File.stubs(:exist?).with("/nonexisting/one.yaml").returns(true)
 
-          @cache.expects(:read).with("/nonexisting/one.yaml", Hash, {}).returns({"key"=>"test_%{rspec}"})
+          @cache.expects(:read_file).with("/nonexisting/one.yaml", Hash).returns({"key"=>"test_%{rspec}"})
 
           @backend.lookup("key", {"rspec" => "test"}, nil, :priority).should == "test_test"
         end
@@ -137,7 +137,7 @@ class Hiera
 
           yaml = "---\nstringval: 'string'\nboolval: true\nnumericval: 1"
 
-          @cache.expects(:read).with("/nonexisting/one.yaml", Hash, {}).times(3).returns({"boolval"=>true, "numericval"=>1, "stringval"=>"string"})
+          @cache.expects(:read_file).with("/nonexisting/one.yaml", Hash).times(3).returns({"boolval"=>true, "numericval"=>1, "stringval"=>"string"})
 
           @backend.lookup("stringval", {}, nil, :priority).should == "string"
           @backend.lookup("boolval", {}, nil, :priority).should == true


### PR DESCRIPTION
The Hiera::Filecache system would swallow any errors that occurred when 
reading or processing a file's contents. This makes it nearly impossible for
any other systems to report errors and where they occurred because they only
show up in logs at debug level.

This changes the Hiera::Filecache to have a new method, read_file, that does
not try to mask errors. The original read method now just handles any errors
that read_file produces. The YAML and JSON backends have been updated to use
read_file so that any malformed YAML or JSON, or unreadable files, are
reported to the caller. This allows, for instance, puppet to properly report
that a value could not be read from hiera when processing data bindings
rather than the value simply not being there and the user getting the
default.
