### PR TITLE
(packaging) (#22905) rm quilt from deb packaging

### DIFF
--- a/ext/debian/control
+++ b/ext/debian/control
@@ -2,7 +2,7 @@ Source: hiera
 Section: utils
 Priority: extra
 Maintainer: Puppet Labs <info@puppetlabs.com>
-Build-Depends: debhelper (>= 7.0.0), cdbs, quilt, ruby | ruby-interpreter
+Build-Depends: debhelper (>= 7.0.0), cdbs, ruby | ruby-interpreter
 Standards-Version: 3.9.2
 Homepage: http://projects.puppetlabs.com/projects/hiera
 


### PR DESCRIPTION
We've added Saucy to the list of distrobutions we support, and it seems
that deb helper has changed slightly with this release. As a result,
building hiera packages for saucy doesn't work. This is because we
require quilt even though we have no patches that we're including. In
order to make sure that we can build hiera on saucy, we need to git rid
of that call to quilt.
