### PR TITLE
(22924) Update packaging to use install.rb

### DIFF
--- a/ext/debian/rules
+++ b/ext/debian/rules
@@ -11,24 +11,18 @@
 
 include /usr/share/cdbs/1/rules/debhelper.mk
 
-BUILD_ROOT=$(DESTDIR)/$(CURDIR)/debian/$(cdbs_curpkg)
+BUILD_ROOT=$(CURDIR)/debian/$(cdbs_curpkg)
 LIBDIR=$(shell /usr/bin/ruby -rrbconfig -e 'puts RbConfig::CONFIG["vendordir"]')
-BIN_DIR=$(shell /usr/bin/ruby -rrbconfig -e 'puts RbConfig::CONFIG["bindir"]')
-RUBYLIB=$(BUILD_ROOT)/$(LIBDIR)
-RUBYBIN=$(BUILD_ROOT)/$(BIN_DIR)
-DOC_DIR=$(BUILD_ROOT)/usr/share/doc/hiera/
-DATA_DIR=$(BUILD_ROOT)/var/lib/hiera
+BINDIR=$(shell /usr/bin/ruby -rrbconfig -e 'puts RbConfig::CONFIG["bindir"]')
+DATADIR=$(BUILD_ROOT)/var/lib/hiera
 
-install/hiera::
-	mkdir -p $(RUBYLIB)
-	mkdir -p $(RUBYBIN)
-	mkdir -p $(DOC_DIR)
-	mkdir -p $(DATA_DIR)
-	mkdir -p $(BUILD_ROOT)/etc
-	cp -pr  lib/hiera $(RUBYLIB)
-	cp -p lib/hiera.rb $(RUBYLIB)
-	cp -p  bin/* $(RUBYBIN)
-	cp -pr ext/hiera.yaml $(BUILD_ROOT)/etc
-	cp -p COPYING README.md $(DOC_DIR)
+binary-install/hiera::
+	mkdir -p $(DATADIR)
+	$(RUBY) $(CURDIR)/install.rb \
+		--destdir=$(CURDIR)/debian/$(cdbs_curpkg) \
+		--sitelibdir=$(LIBDIR) \
+		--bindir=$(BINDIR) \
+		--configdir=/etc \
+		--configs
 
 clean::

--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -7,7 +7,7 @@ summary: 'Light weight hierarchical data store'
 description: 'A pluggable data store for hierarcical data'
 version_file: 'lib/hiera.rb'
 # files and gem_files are space separated lists
-files: '[A-Z]* ext lib bin spec acceptance_tests'
+files: '[A-Z]* ext lib bin spec acceptance_tests install.rb'
 gem_files: '{bin,lib}/**/* COPYING README.md LICENSE'
 gem_require_path: 'lib'
 gem_test_files: 'spec/**/*'

--- a/ext/redhat/hiera.spec.erb
+++ b/ext/redhat/hiera.spec.erb
@@ -10,6 +10,8 @@
 %global _sharedstatedir %{_prefix}/lib
 %endif
 
+%define ruby          %{_bindir}/ruby
+
 # VERSION is subbed out during rake srpm process
 %global realversion <%= @version %>
 %global rpmversion <%= @rpmversion %>
@@ -41,14 +43,23 @@ A simple pluggable Hierarchical Database.
 
 %install
 rm -rf $RPM_BUILD_ROOT
-mkdir -p $RPM_BUILD_ROOT/%{hiera_libdir}
-mkdir -p $RPM_BUILD_ROOT/%{_bindir}
-mkdir -p $RPM_BUILD_ROOT/%{_sysconfdir}
 mkdir -p $RPM_BUILD_ROOT/%{_sharedstatedir}/hiera
-cp -pr lib/hiera $RPM_BUILD_ROOT/%{hiera_libdir}
-cp -pr lib/hiera.rb $RPM_BUILD_ROOT/%{hiera_libdir}
-install -p -m0755 bin/hiera $RPM_BUILD_ROOT/%{_bindir}
-install -p -m0644 ext/hiera.yaml $RPM_BUILD_ROOT/%{_sysconfdir}
+%{ruby} install.rb \
+  --destdir=$RPM_BUILD_ROOT \
+  --configdir=%{_sysconfdir} \
+  --configs \
+  --sitelibdir=%{hiera_libdir}
+
+# Emacs and VIM buts aren't installed and we remove
+# packaging artifacts not applicable to rpm
+for file in ips \
+            debian \
+            osx \
+            redhat \
+            build_defaults.yaml \
+            project_data.yaml ; do
+  rm -rf $RPM_BUILD_ROOT/%{_datadir}/%{_name}/ext/$file ;
+done
 
 %clean
 rm -rf $RPM_BUILD_ROOT


### PR DESCRIPTION
Currently, hiera is using an outdated packaging workflow. This commit
updates the packaging process to use install.rb to get everything into
place.
