### PR TITLE
(#22142) Substantial speed increase in lookups

### DIFF
--- a/lib/hiera/backend/yaml_backend.rb
+++ b/lib/hiera/backend/yaml_backend.rb
@@ -8,6 +8,18 @@ class Hiera
         @cache = cache || Filecache.new
       end
 
+      def datafile(datadir, source, extension)
+        file = File.join([datadir, "#{source}.#{extension}"])
+
+        unless File.exist?(file)
+          Hiera.debug("Cannot find datafile #{file}, skipping")
+
+          return nil
+        end
+
+        return file
+      end
+
       # recursive lookup for key/values inside data. This allows
       # foo::bar, foo::bar::buzz, or even foo::bar::buzz::blam
       def sub_lookup(data, classname, key, delimiter)
@@ -37,9 +49,11 @@ class Hiera
 
         Hiera.debug("Looking up #{key} in YAML backend")
 
+        datadir = Backend.datadir(:yaml, scope)
+
         Backend.datasources(scope, order_override) do |source|
           Hiera.debug("Looking for data source #{source}")
-          yamlfile = Backend.datafile(:yaml, scope, source, "yaml") || next
+          yamlfile = datafile(datadir, source, "yaml") || next
 
           next unless File.exist?(yamlfile)
 


### PR DESCRIPTION
Previously, hiera would look up the 'datadir' from config
inside the loop where it looks inside datafiles. This caused
substantial slowdowns on sites with deep hierarchies.

This commit moves the datadir lookup to be outside the
the datasource-search loop and caused substantial speedups.
(Timings are in the original ticket).

This patch was written by Sean Millichamp; I just rebased it
onto the current state of Hiera and submitted it on his behalf.
