### PR TITLE
ignore empty yaml files

### DIFF
--- a/lib/hiera/backend/yaml_backend.rb
+++ b/lib/hiera/backend/yaml_backend.rb
@@ -20,7 +20,7 @@ class Hiera
           next unless File.exist?(yamlfile)
 
           data = @cache.read_file(yamlfile, Hash) do |data|
-            YAML.load(data)
+            YAML.load(data) || {}
           end
 
           next if data.empty?


### PR DESCRIPTION
YAML.load returns nil for an empty file.
'next if data.empty?' would raise an exception if reached.
