### PR TITLE
(CPR-12) Ensure hiera works with alternatives on debian

### DIFF
--- a/ext/debian/rules
+++ b/ext/debian/rules
@@ -23,6 +23,7 @@ install/hiera::
 		--sitelibdir=$(LIBDIR) \
 		--bindir=$(BINDIR) \
 		--configdir=/etc \
-		--configs
+		--configs \
+		--ruby=/usr/bin/ruby
 
 clean::


### PR DESCRIPTION
Previously the hiera install.rb call in the debian rules did not specify the
ruby binary to use for /usr/bin/hiera. This meant that on wheezy, with a
default ruby of ruby 1.9.3, it would have a shebang of /usr/bin/ruby1.9.1.
Similarly on a platform with a default of ruby 1.8, the shebang would be
/usr/bin/ruby1.8. This means that if the user later updates alternatives to
point to a different ruby, the binary will no longer function as expected. This
commit updates the ruby that will be inserted as the shebang to /usr/bin/ruby
so that alternatives will be more correctly handled.
