### PR TITLE
(hi-149)(packaging) Remove Fedora 18 from the default package builds

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -9,7 +9,7 @@ gpg_name: 'info@puppetlabs.com'
 gpg_key: '4BD6EC30'
 sign_tar: FALSE
 # a space separated list of mock configs
-final_mocks: 'pl-el-5-i386 pl-el-6-i386 pl-el-7-x86_64 pl-fedora-18-i386 pl-fedora-19-i386 pl-fedora-20-i386'
+final_mocks: 'pl-el-5-i386 pl-el-6-i386 pl-el-7-x86_64 pl-fedora-19-i386 pl-fedora-20-i386'
 build_gem: TRUE
 build_dmg: TRUE
 yum_host: 'yum.puppetlabs.com'


### PR DESCRIPTION
Fedora 18 reached end-of-life on 1/14/14. 
This removes Fedora 18 from the list of default package builds.
