### PR TITLE
Allow options to be passed to deep_merge

### DIFF
--- a/lib/hiera/backend.rb
+++ b/lib/hiera/backend.rb
@@ -175,9 +175,9 @@ class Hiera
       def merge_answer(left,right)
         case Config[:merge_behavior]
         when :deeper,'deeper'
-          left.deep_merge!(right)
+          left.deep_merge!(right, Config[:deep_merge_options] || {})
         when :deep,'deep'
-          left.deep_merge(right)
+          left.deep_merge(right, Config[:deep_merge_options] || {})
         else # Native and undefined
           left.merge(right)
         end

--- a/spec/unit/backend_spec.rb
+++ b/spec/unit/backend_spec.rb
@@ -575,13 +575,19 @@ class Hiera
 
       it "uses deep_merge! when configured with :merge_behavior => :deeper" do
         Config.load({:merge_behavior => :deeper})
-        Hash.any_instance.expects('deep_merge!').with({"b" => "bnswer"}).returns({"a" => "answer", "b" => "bnswer"})
+        Hash.any_instance.expects('deep_merge!').with({"b" => "bnswer"}, {}).returns({"a" => "answer", "b" => "bnswer"})
         Backend.merge_answer({"a" => "answer"},{"b" => "bnswer"}).should == {"a" => "answer", "b" => "bnswer"}
       end
 
       it "uses deep_merge when configured with :merge_behavior => :deep" do
         Config.load({:merge_behavior => :deep})
-        Hash.any_instance.expects('deep_merge').with({"b" => "bnswer"}).returns({"a" => "answer", "b" => "bnswer"})
+        Hash.any_instance.expects('deep_merge').with({"b" => "bnswer"}, {}).returns({"a" => "answer", "b" => "bnswer"})
+        Backend.merge_answer({"a" => "answer"},{"b" => "bnswer"}).should == {"a" => "answer", "b" => "bnswer"}
+      end
+
+      it "passes Config[:deep_merge_options] into calls to deep_merge" do
+        Config.load({:merge_behavior => :deep, :deep_merge_options => { :knockout_prefix => '-' } })
+        Hash.any_instance.expects('deep_merge').with({"b" => "bnswer"}, {:knockout_prefix => '-'}).returns({"a" => "answer", "b" => "bnswer"})
         Backend.merge_answer({"a" => "answer"},{"b" => "bnswer"}).should == {"a" => "answer", "b" => "bnswer"}
       end
     end


### PR DESCRIPTION
This enables the end user to customize the configuration of deep_merge
through the hiera configuration file.
