### PR TITLE
Hi 127 escaped lookups

### DIFF
--- a/spec/unit/backend_spec.rb
+++ b/spec/unit/backend_spec.rb
@@ -268,6 +268,12 @@ class Hiera
 
         Backend.parse_string(input, scope).should == "answer"
       end
+
+      it "replaces literal interpolations with their argument" do
+        scope = {}
+        input = "%{literal('%')}{rspec::data}"
+        Backend.parse_string(input, scope).should == "%{rspec::data}"
+      end
     end
 
     describe "#parse_answer" do


### PR DESCRIPTION
The first commit introduces a new Hiera interpolation function, `literal`, which simply returns its argument and breaks out of recursion. This new function can be used to escape Hiera interpolation by doing:

```
%{literal('%')}{some::key}
```

Which resolves to:

```
%{some::key}
```

Since that syntax is quite verbose, the second patch adds an alias that can be used as a shortcut:

```
%{%}{some::key}
```

Resolves to:

```
%{some::key}
```

This should address [HI-127](https://tickets.puppetlabs.com/browse/HI-127)
