### PR TITLE
(HI-232) Hiera should replace ruby-hiera

### DIFF
--- a/ext/debian/control
+++ b/ext/debian/control
@@ -9,5 +9,8 @@ Homepage: http://projects.puppetlabs.com/projects/hiera
 Package: hiera
 Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter, libjson-ruby | ruby-json
+Conflicts: ruby-hiera
+Provides: ruby-hiera
+Replaces: ruby-hiera
 Description: A simple pluggable Hierarchical Database.
 	Hiera is a simple pluggable Hierarchical Database.


### PR DESCRIPTION
Ubuntu provides the package ruby-hiera. This is difficult, because this
causes problems when trying to upgrade from ruby-hiera to hiera. In
order to provide a clean upgrade path from distro package, we need to
make sure our hiera package will corretly replace the ubuntu package.
This commit updates the hiera control file to have a Provides:, Conflicts:,
and Replaces: relationship with ruby-hiera. This will let the system
know that we only allow either hiera or ruby-hiera to be installed at
one time, and, on upgrade to hiera, this will entirely replace
ruby-hiera, forcing the removal of that package.

For more information, see
http://www.debian.org/doc/debian-policy/ch-relationships.html section
7.6.2
