### PR TITLE
Allow for return of complex values across hiera

### DIFF
--- a/lib/hiera/interpolate.rb
+++ b/lib/hiera/interpolate.rb
@@ -11,7 +11,16 @@ class Hiera::Interpolate
         # Wrapping do_interpolation in a gsub block ensures we process
         # each interpolation site in isolation using separate recursion guards.
         data.gsub(INTERPOLATION) do |match|
-          do_interpolation(match, Hiera::RecursiveGuard.new, scope, extra_data)
+          interp_val = do_interpolation(match, Hiera::RecursiveGuard.new, scope, extra_data)
+          if not interp_val or interp_val.is_a?(String)
+            interp_val
+          else
+            # Halt recursion if we get something other than a string in the
+            # hierarchy.
+            # This will return *any* data type that happens to be at the end of
+            # this trail.
+            return interp_val
+          end
         end
       else
         data

--- a/spec/unit/backend_spec.rb
+++ b/spec/unit/backend_spec.rb
@@ -274,6 +274,23 @@ class Hiera
         input = "%{literal('%')}{rspec::data}"
         Backend.parse_string(input, scope).should == "%{rspec::data}"
       end
+
+      it "replaces interpolation values with arrays" do
+        to_test = ['foo','bar']
+        scope = { "rspec" => to_test }
+        input = "%{rspec}"
+
+        Backend.parse_string(input,scope).should == to_test
+      end
+
+      it "replaces interpolation values with hashes" do
+        to_test = {:foo => 'foo',:bar => 'bar'}
+        scope = { "rspec" => to_test }
+        input = "%{rspec}"
+
+        Backend.parse_string(input,scope).should == to_test
+      end
+
     end
 
     describe "#parse_answer" do


### PR DESCRIPTION
This patch provides the ability to use calls to hiera() in various YAML
files to allow for the re-use of Arrays and Hashes across the hiera
space.

For example:
## == foo.yaml ==

foo:
- 'Item One'
- 'Item Two'
## == bar.yaml ==

bar: %{hiera('foo')}

A call to 'hiera bar' would return: ['Item One','Item Two']

This closes HI-183 https://tickets.puppetlabs.com/browse/HI-183
