### PR TITLE
The hierarchy should dynamically grow if an interpolated variable contains an Array type of value

### DIFF
--- a/lib/hiera/backend.rb
+++ b/lib/hiera/backend.rb
@@ -72,8 +72,9 @@ class Hiera
         hierarchy.insert(0, override) if override
 
         hierarchy.flatten.map do |source|
-          source = parse_string(source, scope)
-          yield(source) unless source == "" or source =~ /(^\/|\/\/|\/$)/
+          Hiera::Interpolate.interpolate_hierarchy(source, scope).each do |source|
+            yield(source) unless source == "" or source =~ /(^\/|\/\/|\/$)/
+          end
         end
       end
 


### PR DESCRIPTION
Take the following example:

$roles = ["roleA", "roleB", "roleC"]

environments/%{::environment}/%{::roles}/common

should become:
- environments/%{::environment}/roleA/common
- environments/%{::environment}/roleB/common
- environments/%{::environment}/roleC/common

This pull request is to mainly discuss this feature request. I find it extremely useful in my environment and it allows me to leverage things like Foreman hostgroups etc.
