### PR TITLE
Prefix facts retrieved from mcollective with :: to indicate top level.

### DIFF
--- a/bin/hiera
+++ b/bin/hiera
@@ -55,7 +55,9 @@ def load_scope(source, type=:yaml)
 
       raise "Failed to retrieve facts for node #{source}: #{nodestats[:statusmsg]}" unless nodestats[:statuscode] == 0
 
-      scope = nodestats[:data][:facts]
+      scope = {}
+      nodestats[:data][:facts].each { |key, value| scope["::#{key}"] = value }
+      scope
     rescue Exception => e
       STDERR.puts "MCollective lookup failed: #{e.class}: #{e}"
       exit 1


### PR DESCRIPTION
When hiera retrieves facts from mcollective it does not place them in the top level (by prefixing with ::). Because of this mcollective scope values will not match values in hiera.yaml that are in the form %{::fact}. This patch prefixes :: on all facts that are pulled from mcollective.
