### PR TITLE
(HI-273) Support bundler workflow on windows x64

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,12 +14,11 @@ group :development, :test do
   gem "yarjuf", "~> 1.0"
 end
 
-platform :mswin, :mingw do
-  gem "ffi", "1.9.0", :require => false
-  gem "win32-api", "1.4.8", :require => false
-  gem "win32-dir", "0.4.3", :require => false
-  gem "windows-api", "0.4.2", :require => false
-  gem "windows-pr", "1.2.2", :require => false
+mingw = [:mingw]
+mingw << :x64_mingw if Bundler::Dsl::VALID_PLATFORMS.include?(:x64_mingw)
+
+platform(*mingw) do
+  gem 'win32-dir', '~> 0.4.8', :require => false
 end
 
 if File.exists? "#{__FILE__}.local"


### PR DESCRIPTION
Previously the Gemfile contained windows gem dependencies copy and
pasted from elsewhere.

Hiera only explicitly depends on the `win32-dir` gem to resolve
its data directory on windows, e.g. C:\ProgramData. As such the
Gemfile is updated to include that dependency.
