### PR TITLE
(HI-273) Support bundler workflow on windows x64

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ require 'yaml'
 data = YAML.load_file(File.join(File.dirname(__FILE__), 'ext', 'project_data.yaml'))
 bundle_platforms = data['bundle_platforms']
 data['gem_platform_dependencies'].each_pair do |gem_platform, info|
+  next if gem_platform =~ /mingw/
   if bundle_deps = info['gem_runtime_dependencies']
     bundle_platform = bundle_platforms[gem_platform] or raise "Missing bundle_platform"
     platform(bundle_platform.intern) do
@@ -29,6 +30,12 @@ data['gem_platform_dependencies'].each_pair do |gem_platform, info|
   end
 end
 
+mingw = [:mingw]
+mingw << :x64_mingw if Bundler::Dsl::VALID_PLATFORMS.include?(:x64_mingw)
+
+platform(*mingw) do
+  gem 'win32-dir', '~> 0.4.8', :require => false
+end
 if File.exists? "#{__FILE__}.local"
   eval(File.read("#{__FILE__}.local"), binding)
 end

--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -18,11 +18,10 @@ gem_default_executables: 'hiera'
 gem_platform_dependencies:
   x86-mingw32:
     gem_runtime_dependencies:
-      ffi: '1.9.0'
-      win32-api: '1.4.8'
-      win32-dir: '0.4.3'
-      windows-api: '0.4.2'
-      windows-pr: '1.2.2'
-      win32console: '1.3.2'
+      win32-dir: '~> 0.4.8'
+  x64-mingw32:
+    gem_runtime_dependencies:
+      win32-dir: '~> 0.4.8'
 bundle_platforms:
   x86-mingw32: mingw
+  x64-mingw32: x64_mingw


### PR DESCRIPTION
Previously the Gemfile contained windows gem dependencies copy and
pasted from elsewhere.

Hiera only explicitly depends on the `win32-dir` gem to resolve
its data directory on windows, e.g. C:\ProgramData. As such the
Gemfile is updated to include that dependency.

The dependency is also specified in the project_data.yaml file used
when creating platform specific gems.
