### PR TITLE
(HI-273) Build architecture specific Windows gems

### DIFF
--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -15,3 +15,13 @@ gem_executables: 'hiera'
 gem_runtime_dependencies:
   json_pure:
 gem_default_executables: 'hiera'
+gem_platform_dependencies:
+  x86-mingw32:
+    gem_runtime_dependencies:
+      win32-dir: '~> 0.4.8'
+  x64-mingw32:
+    gem_runtime_dependencies:
+      win32-dir: '~> 0.4.8'
+bundle_platforms:
+  x86-mingw32: mingw
+  x64-mingw32: x64_mingw


### PR DESCRIPTION
- Ensure that packaging tasks correctly build the Hiera gem on Windows
  by including additional definitions
