### PR TITLE
(HI-279) Hiera README.md should express semver

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,5 +235,25 @@ See LICENSE file.
 
 ## Support
 
-Please log tickets and issues at our [Projects site](http://projects.puppetlabs.com)
+Please log tickets and issues at our [JIRA tracker](http://tickets.puppetlabs.com).  A [mailing
+list](https://groups.google.com/forum/?fromgroups#!forum/puppet-users) is
+available for asking questions and getting help from others. In addition there
+is an active #puppet channel on Freenode.
 
+We use semantic version numbers for our releases, and recommend that users stay
+as up-to-date as possible by upgrading to patch releases and minor releases as
+they become available.
+
+Bugfixes and ongoing development will occur in minor releases for the current
+major version. Security fixes will be backported to a previous major version on
+a best-effort basis, until the previous major version is no longer maintained.
+
+
+For example: If a security vulnerability is discovered in Hiera 1.3.0, we
+would fix it in the 1 series, most likely as 1.3.1. Maintainers would then make
+a best effort to backport that fix onto the latest Hiera release they carry.
+
+Long-term support, including security patches and bug fixes, is available for
+commercial customers. Please see the following page for more details:
+
+[Puppet Enterprise Support Lifecycle](http://puppetlabs.com/misc/puppet-enterprise-lifecycle)


### PR DESCRIPTION
The puppet readme (https://github.com/puppetlabs/puppet/blob/master/README.md)
explains the maintenance we have for versions of puppet and that it is
semantically versioned. We recently encountered an issue with Facter where
users were surprised that we did not ship a security release for a previous
major version of facter. The previous assumption may have been that the puppet
README was sufficient for all of our FOSS projects, but this is probably not
the case. We should update the README.md in Hiera with the same verbage as
puppet so our intended release lifecycle is clear.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
