### PR TITLE
Fixes rake tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,7 @@
 begin
-  load File.join(File.dirname(__FILE__), 'ext', 'packaging', 'packaging.rake')
   require 'rubygems'
   require 'rspec/core/rake_task'
+  load File.join(File.dirname(__FILE__), 'ext', 'packaging', 'packaging.rake')
 rescue LoadError
 end
 


### PR DESCRIPTION
Currently the Rakefile is setup to load files for building the release
packages but is erroring out before `rubygems` and `rspec/core/raketask` are
being loaded causing the rake spec tasks to not be created only if the
packaging repo has not been bootstrapped. This prevents you from running
`rake spec` in a bare repository.

This commit changes the loading order so that rake will gracefully load
the file and create the rake spec tasks regardless of if the packaging
repo has been bootstrapped or not.
