### PR TITLE
(HI-289) expand Hiera basic functionality acceptance tests

### DIFF
--- a/acceptance_tests/tests/basic_functionality/check_first_backend_hierarchy_first.rb
+++ b/acceptance_tests/tests/basic_functionality/check_first_backend_hierarchy_first.rb
@@ -1,0 +1,92 @@
+test_name "should check first backend hierarchy first"
+
+global_data_yaml = 'global.yaml'
+global_data_json = 'global.json'
+agents.each do |this_agent|
+  if this_agent['platform'] =~ /windows/
+    datadir = 'C:/PROGRA~3/PuppetLabs/hiera/var/'
+  else
+    datadir = '/etc/puppet/hieradata'
+  end
+  data_file_yaml = File.join(datadir, global_data_yaml)
+  data_file_json = File.join(datadir, global_data_json)
+
+  conf_content = <<-CONF
+---
+  :backends:
+    - "json"
+    - "yaml"
+  :hierarchy:
+    - "global"
+
+  :yaml:
+    :datadir: "#{datadir}"
+  :json:
+    :datadir: "#{datadir}"
+  CONF
+
+  yaml_data = <<-YAML
+---
+foo: barYaml
+foo2: bar2Yaml
+  YAML
+
+  json_data = <<-JSON
+{
+  "foo": "barJson",
+  "foo2": "bar2Json"
+}
+  JSON
+
+  step "backup config; config with two backends; create two hierarchies"
+  confPath = {}
+  if this_agent['platform'] =~ /windows/
+    confPath = on(this_agent, "echo #{this_agent['hieraconf']}")
+    confPath = confPath.raw_output.chomp
+  else # hieraconf incorrect for CLI in unix
+    confPath = '/etc/hiera.yaml'
+  end
+  on(this_agent, "if [ -f #{confPath} ]; then cp '#{confPath}' '#{confPath}.bak'; fi")
+  create_remote_file(this_agent, confPath, conf_content )
+  on(this_agent, "rm -rf '#{datadir}'")
+  on(this_agent, "mkdir -p '#{datadir}'")
+  create_remote_file(this_agent, data_file_yaml, yaml_data)
+  create_remote_file(this_agent, data_file_json, json_data)
+
+  step "lookup data"
+  on(this_agent, hiera("-c '#{confPath}' ", 'foo')) do
+    assert_output <<-OUTPUT
+      STDOUT> barJson
+    OUTPUT
+  end
+
+  step "swap hierarchy order; and lookup data again"
+  conf_content = <<-CONF
+---
+  :backends:
+    - "yaml"
+    - "json"
+  :logger: "console"
+  :hierarchy:
+    - "%{fqdn}"
+    - "%{environment}"
+    - "global"
+
+  :yaml:
+    :datadir: "#{datadir}"
+  :json:
+    :datadir: "#{datadir}"
+  CONF
+
+  create_remote_file(this_agent, confPath, conf_content)
+  on(this_agent, hiera("-c '#{confPath}' ", 'foo')) do
+    assert_output <<-OUTPUT
+      STDOUT> barYaml
+    OUTPUT
+  end
+
+  teardown do
+    on(this_agent, "rm -rf '#{datadir}'")
+    on(this_agent, "if [ -f #{confPath}.bak ]; then mv '#{confPath}.bak' '#{confPath}'; fi")
+  end
+end

--- a/acceptance_tests/tests/basic_functionality/default_value_if_key_not_found.rb
+++ b/acceptance_tests/tests/basic_functionality/default_value_if_key_not_found.rb
@@ -1,0 +1,10 @@
+test_name "use the default value if key not found"
+
+step "lookup data with default"
+agents.each do |this_agent|
+  on(this_agent, hiera('foo', 'bar42')) do
+    assert_output <<-OUTPUT
+      STDOUT> bar42
+    OUTPUT
+  end
+end

--- a/acceptance_tests/tests/basic_functionality/lookup_data_no_options.rb
+++ b/acceptance_tests/tests/basic_functionality/lookup_data_no_options.rb
@@ -1,0 +1,35 @@
+test_name "Lookup data with no options"
+# this test will break if someone leaves a weird config file lying around...
+# but we want to test a default install, so it will remain fragile
+
+step "create common data file"
+agents.each do |this_agent|
+  if this_agent['platform'] =~ /windows/
+    datadir = 'C:/PROGRA~3/PuppetLabs/hiera/var/'
+  else
+    datadir = '/var/lib/hiera/'
+  end
+
+  commonYaml = 'global.yaml'
+  data_file = File.join(datadir, commonYaml)
+
+  common_content = <<-HERE
+---
+foo: bar
+  HERE
+
+  on(this_agent, "rm -rf '#{datadir}'")
+  on(this_agent, "mkdir  '#{datadir}'")
+  create_remote_file(this_agent, data_file, common_content)
+
+  step "lookup data"
+  on(this_agent, hiera('foo')) do
+    assert_output <<-OUTPUT
+      STDOUT> bar
+    OUTPUT
+  end
+
+  teardown do
+    on(this_agent, "rm -rf '#{datadir}'")
+  end
+end


### PR DESCRIPTION
(HI-289) expand basic functionality acceptance tests  
three tests added:
  lookup_data_no_options - tests a simple priority lookup of a string from
    CLI
  default_value_if_key_not_found tests - that default value is used when
    key not found from CLI
  check_first_backend_hierarchy_first - tests multiple backends to ensure
    each hierarchy is checked in order as in the config file

(HI-289) expand basic functionality tests to work in windows and
solaris11.
make tests more atomic and remove 00-setup.rb
