### PR TITLE
(HI-303) Add deep_merge dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
 gem "hiera", :path => File.dirname(__FILE__), :require => false
+gem 'deep_merge', :require => false
 
 group :development do
   gem 'watchr'


### PR DESCRIPTION
Deep_merge is an optional dependency of Hiera. Call it out here so it
will be used when available.
