### PR TITLE
Restore "(HI-304) Make order override work with interpolation"

### DIFF
--- a/lib/hiera/backend/json_backend.rb
+++ b/lib/hiera/backend/json_backend.rb
@@ -33,7 +33,7 @@ class Hiera
           # the array
           #
           # for priority searches we break after the first found data item
-          new_answer = Backend.parse_answer(data[key], scope)
+          new_answer = Backend.parse_answer(data[key], scope, order_override)
           case resolution_type
           when :array
             raise Exception, "Hiera type mismatch for key '#{key}': expected Array and got #{new_answer.class}" unless new_answer.kind_of? Array or new_answer.kind_of? String

--- a/lib/hiera/backend/yaml_backend.rb
+++ b/lib/hiera/backend/yaml_backend.rb
@@ -32,7 +32,7 @@ class Hiera
           # the array
           #
           # for priority searches we break after the first found data item
-          new_answer = Backend.parse_answer(data[key], scope)
+          new_answer = Backend.parse_answer(data[key], scope, order_override)
           case resolution_type
           when :array
             raise Exception, "Hiera type mismatch for key '#{key}': expected Array and got #{new_answer.class}" unless new_answer.kind_of? Array or new_answer.kind_of? String

--- a/lib/hiera/interpolate.rb
+++ b/lib/hiera/interpolate.rb
@@ -9,12 +9,12 @@ class Hiera::Interpolate
     INTERPOLATION = /%\{([^\}]*)\}/
     METHOD_INTERPOLATION = /%\{(scope|hiera|literal|alias)\(['"]([^"']*)["']\)\}/
 
-    def interpolate(data, scope, extra_data)
+    def interpolate(data, scope, override, extra_data)
       if data.is_a?(String)
         # Wrapping do_interpolation in a gsub block ensures we process
         # each interpolation site in isolation using separate recursion guards.
         data.gsub(INTERPOLATION) do |match|
-          interp_val = do_interpolation(match, Hiera::RecursiveGuard.new, scope, extra_data)
+          interp_val = do_interpolation(match, Hiera::RecursiveGuard.new, scope, override, extra_data)
 
           # Get interp method in case we are aliasing
           if data.is_a?(String) && (match = data.match(INTERPOLATION))
@@ -38,17 +38,17 @@ class Hiera::Interpolate
       end
     end
 
-    def do_interpolation(data, recurse_guard, scope, extra_data)
+    def do_interpolation(data, recurse_guard, scope, override, extra_data)
       if data.is_a?(String) && (match = data.match(INTERPOLATION))
         interpolation_variable = match[1]
         recurse_guard.check(interpolation_variable) do
           interpolate_method, key = get_interpolation_method_and_key(data)
-          interpolated_data = send(interpolate_method, data, key, scope, extra_data)
+          interpolated_data = send(interpolate_method, data, key, scope, override, extra_data)
 
           # Halt recursion if we encounter a literal.
           return interpolated_data if interpolate_method == :literal_interpolate
 
-          do_interpolation(interpolated_data, recurse_guard, scope, extra_data)
+          do_interpolation(interpolated_data, recurse_guard, scope, override, extra_data)
         end
       else
         data
@@ -70,7 +70,7 @@ class Hiera::Interpolate
     end
     private :get_interpolation_method_and_key
 
-    def scope_interpolate(data, key, scope, extra_data)
+    def scope_interpolate(data, key, scope, override, extra_data)
       value = scope[key]
       if value.nil? || value == :undefined
         value = extra_data[key]
@@ -80,18 +80,18 @@ class Hiera::Interpolate
     end
     private :scope_interpolate
 
-    def hiera_interpolate(data, key, scope, extra_data)
-      Hiera::Backend.lookup(key, nil, scope, nil, :priority)
+    def hiera_interpolate(data, key, scope, override, extra_data)
+      Hiera::Backend.lookup(key, nil, scope, override, :priority)
     end
     private :hiera_interpolate
 
-    def literal_interpolate(data, key, scope, extra_data)
+    def literal_interpolate(data, key, scope, override, extra_data)
       key
     end
     private :literal_interpolate
 
-    def alias_interpolate(data, key, scope, extra_data)
-      Hiera::Backend.lookup(key, nil, scope, nil, :priority)
+    def alias_interpolate(data, key, scope, override, extra_data)
+      Hiera::Backend.lookup(key, nil, scope, override, :priority)
     end
     private :alias_interpolate
   end

--- a/spec/unit/backend/json_backend_spec.rb
+++ b/spec/unit/backend/json_backend_spec.rb
@@ -54,7 +54,7 @@ class Hiera
 
         it "should build an array of all data sources for array searches" do
           Hiera::Backend.stubs(:empty_answer).returns([])
-          Backend.stubs(:parse_answer).with('answer', {}).returns("answer")
+          Backend.stubs(:parse_answer).with('answer', {}, nil).returns("answer")
           Backend.expects(:datafile).with(:json, {}, "one", "json").returns("/nonexisting/one.json")
           Backend.expects(:datafile).with(:json, {}, "two", "json").returns("/nonexisting/two.json")
 
@@ -70,7 +70,7 @@ class Hiera
         end
 
         it "should parse the answer for scope variables" do
-          Backend.stubs(:parse_answer).with('test_%{rspec}', {'rspec' => 'test'}).returns("test_test")
+          Backend.stubs(:parse_answer).with('test_%{rspec}', {'rspec' => 'test'}, nil).returns("test_test")
           Backend.expects(:datasources).yields("one")
           Backend.expects(:datafile).with(:json, {"rspec" => "test"}, "one", "json").returns("/nonexisting/one.json")
 


### PR DESCRIPTION
Reverts puppetlabs/hiera#222 to re-apply fix to Hiera. #222 was to address failures in Puppet's acceptance tests due to the change.

Some discussion is needed to ensure this change can be made, and fixes applied to puppet, without introducing breaking changes.
