### PR TITLE
(HI-304) Make order override work with interpolation

### DIFF
--- a/lib/hiera/backend/json_backend.rb
+++ b/lib/hiera/backend/json_backend.rb
@@ -33,7 +33,7 @@ class Hiera
           # the array
           #
           # for priority searches we break after the first found data item
-          new_answer = Backend.parse_answer(data[key], scope, nil, recurse_guard)
+          new_answer = Backend.parse_answer(data[key], scope, {}, {:order_override => order_override, :recurse_guard => recurse_guard})
           case resolution_type
           when :array
             raise Exception, "Hiera type mismatch for key '#{key}': expected Array and got #{new_answer.class}" unless new_answer.kind_of? Array or new_answer.kind_of? String

--- a/lib/hiera/backend/json_backend.rb
+++ b/lib/hiera/backend/json_backend.rb
@@ -9,7 +9,7 @@ class Hiera
         @cache = cache || Filecache.new
       end
 
-      def lookup(key, scope, order_override, resolution_type, recurse_guard)
+      def lookup(key, scope, order_override, resolution_type, context)
         answer = nil
 
         Hiera.debug("Looking up #{key} in JSON backend")
@@ -33,7 +33,7 @@ class Hiera
           # the array
           #
           # for priority searches we break after the first found data item
-          new_answer = Backend.parse_answer(data[key], scope, {}, {:order_override => order_override, :recurse_guard => recurse_guard})
+          new_answer = Backend.parse_answer(data[key], scope, {}, context)
           case resolution_type
           when :array
             raise Exception, "Hiera type mismatch for key '#{key}': expected Array and got #{new_answer.class}" unless new_answer.kind_of? Array or new_answer.kind_of? String

--- a/lib/hiera/backend/yaml_backend.rb
+++ b/lib/hiera/backend/yaml_backend.rb
@@ -32,7 +32,7 @@ class Hiera
           # the array
           #
           # for priority searches we break after the first found data item
-          new_answer = Backend.parse_answer(data[key], scope, nil, recurse_guard)
+          new_answer = Backend.parse_answer(data[key], scope, {}, {:recurse_guard => recurse_guard, :order_override => order_override})
           case resolution_type
           when :array
             raise Exception, "Hiera type mismatch for key '#{key}': expected Array and got #{new_answer.class}" unless new_answer.kind_of? Array or new_answer.kind_of? String

--- a/lib/hiera/backend/yaml_backend.rb
+++ b/lib/hiera/backend/yaml_backend.rb
@@ -8,7 +8,7 @@ class Hiera
         @cache = cache || Filecache.new
       end
 
-      def lookup(key, scope, order_override, resolution_type, recurse_guard)
+      def lookup(key, scope, order_override, resolution_type, context)
         answer = nil
 
         Hiera.debug("Looking up #{key} in YAML backend")
@@ -32,7 +32,7 @@ class Hiera
           # the array
           #
           # for priority searches we break after the first found data item
-          new_answer = Backend.parse_answer(data[key], scope, {}, {:recurse_guard => recurse_guard, :order_override => order_override})
+          new_answer = Backend.parse_answer(data[key], scope, {}, context)
           case resolution_type
           when :array
             raise Exception, "Hiera type mismatch for key '#{key}': expected Array and got #{new_answer.class}" unless new_answer.kind_of? Array or new_answer.kind_of? String

--- a/lib/hiera/interpolate.rb
+++ b/lib/hiera/interpolate.rb
@@ -9,13 +9,15 @@ class Hiera::Interpolate
     INTERPOLATION = /%\{([^\}]*)\}/
     METHOD_INTERPOLATION = /%\{(scope|hiera|literal|alias)\(['"]([^"']*)["']\)\}/
 
-    def interpolate(data, scope, extra_data, recurse_guard, order_override)
+    def interpolate(data, scope, extra_data, context)
       if data.is_a?(String)
         # Wrapping do_interpolation in a gsub block ensures we process
         # each interpolation site in isolation using separate recursion guards.
-        recurse_guard ||= Hiera::RecursiveGuard.new
+        context ||= {}
+        new_context = context.clone
+        new_context[:recurse_guard] ||= Hiera::RecursiveGuard.new
         data.gsub(INTERPOLATION) do |match|
-          interp_val = do_interpolation(match, recurse_guard, scope, order_override, extra_data)
+          interp_val = do_interpolation(match, scope, extra_data, new_context)
 
           # Get interp method in case we are aliasing
           if data.is_a?(String) && (match = data.match(INTERPOLATION))
@@ -39,17 +41,17 @@ class Hiera::Interpolate
       end
     end
 
-    def do_interpolation(data, recurse_guard, scope, order_override, extra_data)
+    def do_interpolation(data, scope, extra_data, context)
       if data.is_a?(String) && (match = data.match(INTERPOLATION))
         interpolation_variable = match[1]
-        recurse_guard.check(interpolation_variable) do
+        context[:recurse_guard].check(interpolation_variable) do
           interpolate_method, key = get_interpolation_method_and_key(data)
-          interpolated_data = send(interpolate_method, data, key, scope, extra_data, recurse_guard, order_override)
+          interpolated_data = send(interpolate_method, data, key, scope, extra_data, context)
 
           # Halt recursion if we encounter a literal.
           return interpolated_data if interpolate_method == :literal_interpolate
 
-          do_interpolation(interpolated_data, recurse_guard, scope, order_override, extra_data)
+          do_interpolation(interpolated_data, scope, extra_data, context)
         end
       else
         data
@@ -71,25 +73,25 @@ class Hiera::Interpolate
     end
     private :get_interpolation_method_and_key
 
-    def scope_interpolate(data, key, scope, extra_data, recurse_guard, order_override)
+    def scope_interpolate(data, key, scope, extra_data, context)
       segments = key.split('.')
       value = Hiera::Backend.qualified_lookup(segments, scope)
       value.nil? ? Hiera::Backend.qualified_lookup(segments, extra_data) : value
     end
     private :scope_interpolate
 
-    def hiera_interpolate(data, key, scope, extra_data, recurse_guard, order_override)
-      Hiera::Backend.lookup(key, nil, scope, order_override, :priority, recurse_guard)
+    def hiera_interpolate(data, key, scope, extra_data, context)
+      Hiera::Backend.lookup(key, nil, scope, context[:order_override], :priority, context)
     end
     private :hiera_interpolate
 
-    def literal_interpolate(data, key, scope, extra_data, recurse_guard, order_override)
+    def literal_interpolate(data, key, scope, extra_data, context)
       key
     end
     private :literal_interpolate
 
-    def alias_interpolate(data, key, scope, extra_data, recurse_guard, order_override)
-      Hiera::Backend.lookup(key, nil, scope, order_override, :priority, recurse_guard)
+    def alias_interpolate(data, key, scope, extra_data, context)
+      Hiera::Backend.lookup(key, nil, scope, context[:order_override], :priority, context)
     end
     private :alias_interpolate
   end

--- a/lib/hiera/interpolate.rb
+++ b/lib/hiera/interpolate.rb
@@ -9,13 +9,13 @@ class Hiera::Interpolate
     INTERPOLATION = /%\{([^\}]*)\}/
     METHOD_INTERPOLATION = /%\{(scope|hiera|literal|alias)\(['"]([^"']*)["']\)\}/
 
-    def interpolate(data, scope, extra_data, recurse_guard)
+    def interpolate(data, scope, extra_data, recurse_guard, order_override)
       if data.is_a?(String)
         # Wrapping do_interpolation in a gsub block ensures we process
         # each interpolation site in isolation using separate recursion guards.
         recurse_guard ||= Hiera::RecursiveGuard.new
         data.gsub(INTERPOLATION) do |match|
-          interp_val = do_interpolation(match, recurse_guard, scope, extra_data)
+          interp_val = do_interpolation(match, recurse_guard, scope, order_override, extra_data)
 
           # Get interp method in case we are aliasing
           if data.is_a?(String) && (match = data.match(INTERPOLATION))
@@ -39,17 +39,17 @@ class Hiera::Interpolate
       end
     end
 
-    def do_interpolation(data, recurse_guard, scope, extra_data)
+    def do_interpolation(data, recurse_guard, scope, order_override, extra_data)
       if data.is_a?(String) && (match = data.match(INTERPOLATION))
         interpolation_variable = match[1]
         recurse_guard.check(interpolation_variable) do
           interpolate_method, key = get_interpolation_method_and_key(data)
-          interpolated_data = send(interpolate_method, data, key, scope, extra_data, recurse_guard)
+          interpolated_data = send(interpolate_method, data, key, scope, extra_data, recurse_guard, order_override)
 
           # Halt recursion if we encounter a literal.
           return interpolated_data if interpolate_method == :literal_interpolate
 
-          do_interpolation(interpolated_data, recurse_guard, scope, extra_data)
+          do_interpolation(interpolated_data, recurse_guard, scope, order_override, extra_data)
         end
       else
         data
@@ -71,25 +71,25 @@ class Hiera::Interpolate
     end
     private :get_interpolation_method_and_key
 
-    def scope_interpolate(data, key, scope, extra_data, recurse_guard)
+    def scope_interpolate(data, key, scope, extra_data, recurse_guard, order_override)
       segments = key.split('.')
       value = Hiera::Backend.qualified_lookup(segments, scope)
       value.nil? ? Hiera::Backend.qualified_lookup(segments, extra_data) : value
     end
     private :scope_interpolate
 
-    def hiera_interpolate(data, key, scope, extra_data, recurse_guard)
-      Hiera::Backend.lookup(key, nil, scope, nil, :priority, recurse_guard)
+    def hiera_interpolate(data, key, scope, extra_data, recurse_guard, order_override)
+      Hiera::Backend.lookup(key, nil, scope, order_override, :priority, recurse_guard)
     end
     private :hiera_interpolate
 
-    def literal_interpolate(data, key, scope, extra_data, recurse_guard)
+    def literal_interpolate(data, key, scope, extra_data, recurse_guard, order_override)
       key
     end
     private :literal_interpolate
 
-    def alias_interpolate(data, key, scope, extra_data, recurse_guard)
-      Hiera::Backend.lookup(key, nil, scope, nil, :priority, recurse_guard)
+    def alias_interpolate(data, key, scope, extra_data, recurse_guard, order_override)
+      Hiera::Backend.lookup(key, nil, scope, order_override, :priority, recurse_guard)
     end
     private :alias_interpolate
   end

--- a/spec/unit/backend/json_backend_spec.rb
+++ b/spec/unit/backend/json_backend_spec.rb
@@ -54,7 +54,7 @@ class Hiera
 
         it "should build an array of all data sources for array searches" do
           Hiera::Backend.stubs(:empty_answer).returns([])
-          Backend.stubs(:parse_answer).with('answer', {}, nil, nil).returns("answer")
+          Backend.stubs(:parse_answer).with('answer', {}, {}, {:recurse_guard => nil, :order_override => nil}).returns("answer")
           Backend.expects(:datafile).with(:json, {}, "one", "json").returns("/nonexisting/one.json")
           Backend.expects(:datafile).with(:json, {}, "two", "json").returns("/nonexisting/two.json")
 
@@ -70,7 +70,7 @@ class Hiera
         end
 
         it "should parse the answer for scope variables" do
-          Backend.stubs(:parse_answer).with('test_%{rspec}', {'rspec' => 'test'}, nil, nil).returns("test_test")
+          Backend.stubs(:parse_answer).with('test_%{rspec}', {'rspec' => 'test'}, {}, {:recurse_guard => nil, :order_override => nil}).returns("test_test")
           Backend.expects(:datasources).yields("one")
           Backend.expects(:datafile).with(:json, {"rspec" => "test"}, "one", "json").returns("/nonexisting/one.json")
 

--- a/spec/unit/backend/json_backend_spec.rb
+++ b/spec/unit/backend/json_backend_spec.rb
@@ -54,7 +54,7 @@ class Hiera
 
         it "should build an array of all data sources for array searches" do
           Hiera::Backend.stubs(:empty_answer).returns([])
-          Backend.stubs(:parse_answer).with('answer', {}, {}, {:recurse_guard => nil, :order_override => nil}).returns("answer")
+          Backend.stubs(:parse_answer).with('answer', {}, {}, anything).returns("answer")
           Backend.expects(:datafile).with(:json, {}, "one", "json").returns("/nonexisting/one.json")
           Backend.expects(:datafile).with(:json, {}, "two", "json").returns("/nonexisting/two.json")
 
@@ -70,7 +70,7 @@ class Hiera
         end
 
         it "should parse the answer for scope variables" do
-          Backend.stubs(:parse_answer).with('test_%{rspec}', {'rspec' => 'test'}, {}, {:recurse_guard => nil, :order_override => nil}).returns("test_test")
+          Backend.stubs(:parse_answer).with('test_%{rspec}', {'rspec' => 'test'}, {}, anything).returns("test_test")
           Backend.expects(:datasources).yields("one")
           Backend.expects(:datafile).with(:json, {"rspec" => "test"}, "one", "json").returns("/nonexisting/one.json")
 

--- a/spec/unit/backend_spec.rb
+++ b/spec/unit/backend_spec.rb
@@ -92,7 +92,7 @@ class Hiera
       end
 
       it "parses the names of the hierarchy levels using the given scope" do
-        Backend.expects(:parse_string).with("common", {:rspec => :tests})
+        Backend.expects(:parse_string).with("common", {:rspec => :tests}, {}, {:order_override => nil})
         Backend.datasources({:rspec => :tests}) { }
       end
 
@@ -264,6 +264,11 @@ class Hiera
         Backend::Yaml_backend.any_instance.stubs(:lookup).with("key1", scope, nil, :priority, instance_of(RecursiveGuard)).returns("answer")
 
         Backend.parse_string(input, scope).should == "answer"
+      end
+
+      it "interpolation passes the order_override back into the backend" do
+        Backend.expects(:lookup).with("lookup::key", nil, {}, "order_override_datasource", :priority, instance_of(RecursiveGuard))
+        Backend.parse_string("%{hiera('lookup::key')}", {}, {}, {:order_override => "order_override_datasource"})
       end
 
       it "replaces literal interpolations with their argument" do

--- a/spec/unit/backend_spec.rb
+++ b/spec/unit/backend_spec.rb
@@ -261,13 +261,13 @@ class Hiera
         scope = {}
         Config.load({:yaml => {:datadir => "/tmp"}})
         Config.load_backends
-        Backend::Yaml_backend.any_instance.stubs(:lookup).with("key1", scope, nil, :priority, instance_of(RecursiveGuard)).returns("answer")
+        Backend::Yaml_backend.any_instance.stubs(:lookup).with("key1", scope, nil, :priority, instance_of(Hash)).returns("answer")
 
         Backend.parse_string(input, scope).should == "answer"
       end
 
       it "interpolation passes the order_override back into the backend" do
-        Backend.expects(:lookup).with("lookup::key", nil, {}, "order_override_datasource", :priority, instance_of(RecursiveGuard))
+        Backend.expects(:lookup).with("lookup::key", nil, {}, "order_override_datasource", :priority, instance_of(Hash))
         Backend.parse_string("%{hiera('lookup::key')}", {}, {}, {:order_override => "order_override_datasource"})
       end
 
@@ -314,7 +314,7 @@ class Hiera
         scope = {}
         Config.load({:yaml => {:datadir => "/tmp"}})
         Config.load_backends
-        Backend::Yaml_backend.any_instance.stubs(:lookup).with("rspec", scope, nil, :priority, instance_of(RecursiveGuard)).returns("test")
+        Backend::Yaml_backend.any_instance.stubs(:lookup).with("rspec", scope, nil, :priority, instance_of(Hash)).returns("test")
         Backend.parse_answer(input, scope).should == "test_test_test"
       end
 
@@ -323,7 +323,7 @@ class Hiera
         scope = {}
         Config.load({:yaml => {:datadir => "/tmp"}})
         Config.load_backends
-        Backend::Yaml_backend.any_instance.stubs(:lookup).with("rspec", scope, nil, :priority, instance_of(RecursiveGuard)).returns(['test', 'test'])
+        Backend::Yaml_backend.any_instance.stubs(:lookup).with("rspec", scope, nil, :priority, instance_of(Hash)).returns(['test', 'test'])
         Backend.parse_answer(input, scope).should == ['test', 'test']
       end
 
@@ -332,7 +332,7 @@ class Hiera
         scope = {}
         Config.load({:yaml => {:datadir => "/tmp"}})
         Config.load_backends
-        Backend::Yaml_backend.any_instance.stubs(:lookup).with("rspec", scope, nil, :priority, instance_of(RecursiveGuard)).returns(['test', 'test'])
+        Backend::Yaml_backend.any_instance.stubs(:lookup).with("rspec", scope, nil, :priority, instance_of(Hash)).returns(['test', 'test'])
         expect do
           Backend.parse_answer(input, scope).should == ['test', 'test']
         end.to raise_error(Hiera::InterpolationInvalidValue, 'Cannot call alias in the string context')
@@ -343,7 +343,7 @@ class Hiera
         scope = {}
         Config.load({:yaml => {:datadir => "/tmp"}})
         Config.load_backends
-        Backend::Yaml_backend.any_instance.stubs(:lookup).with("rspec", scope, nil, :priority, instance_of(RecursiveGuard)).returns(['test', 'test'])
+        Backend::Yaml_backend.any_instance.stubs(:lookup).with("rspec", scope, nil, :priority, instance_of(Hash)).returns(['test', 'test'])
         expect do
           Backend.parse_answer(input, scope).should == ['test', 'test']
         end.to raise_error(Hiera::InterpolationInvalidValue, 'Cannot call alias in the string context')
@@ -354,7 +354,7 @@ class Hiera
         scope = {}
         Config.load({:yaml => {:datadir => "/tmp"}})
         Config.load_backends
-        Backend::Yaml_backend.any_instance.stubs(:lookup).with("rspec", scope, nil, :priority, instance_of(RecursiveGuard)).returns("test")
+        Backend::Yaml_backend.any_instance.stubs(:lookup).with("rspec", scope, nil, :priority, instance_of(Hash)).returns("test")
         Backend.parse_answer(input, scope).should == ["test_test_test", "test_test_test", ["test_test_test"]]
       end
 
@@ -363,7 +363,7 @@ class Hiera
         scope = {}
         Config.load({:yaml => {:datadir => "/tmp"}})
         Config.load_backends
-        Backend::Yaml_backend.any_instance.stubs(:lookup).with("rspec", scope, nil, :priority, instance_of(RecursiveGuard)).returns("test")
+        Backend::Yaml_backend.any_instance.stubs(:lookup).with("rspec", scope, nil, :priority, instance_of(Hash)).returns("test")
         Backend.parse_answer(input, scope).should == {"foo"=>"test_test_test", "bar"=>"test_test_test"}
       end
 
@@ -372,7 +372,7 @@ class Hiera
         scope = {}
         Config.load({:yaml => {:datadir => "/tmp"}})
         Config.load_backends
-        Backend::Yaml_backend.any_instance.stubs(:lookup).with("rspec", scope, nil, :priority, instance_of(RecursiveGuard)).returns("foo")
+        Backend::Yaml_backend.any_instance.stubs(:lookup).with("rspec", scope, nil, :priority, instance_of(Hash)).returns("foo")
         Backend.parse_answer(input, scope).should == {"foo"=>"test"}
       end
 
@@ -381,7 +381,7 @@ class Hiera
         scope = {}
         Config.load({:yaml => {:datadir => "/tmp"}})
         Config.load_backends
-        Backend::Yaml_backend.any_instance.stubs(:lookup).with("rspec", scope, nil, :priority, instance_of(RecursiveGuard)).returns("foo")
+        Backend::Yaml_backend.any_instance.stubs(:lookup).with("rspec", scope, nil, :priority, instance_of(Hash)).returns("foo")
         Backend.parse_answer(input, scope).should == {"topkey"=>{"foo" => "test"}}
       end
 
@@ -390,7 +390,7 @@ class Hiera
         scope = {}
         Config.load({:yaml => {:datadir => "/tmp"}})
         Config.load_backends
-        Backend::Yaml_backend.any_instance.stubs(:lookup).with("rspec", scope, nil, :priority, instance_of(RecursiveGuard)).returns("test")
+        Backend::Yaml_backend.any_instance.stubs(:lookup).with("rspec", scope, nil, :priority, instance_of(Hash)).returns("test")
         Backend.parse_answer(input, scope).should == {"foo"=>"test_test_test", "bar"=>["test_test_test", "test_test_test"]}
       end
 
@@ -399,7 +399,7 @@ class Hiera
         scope = {"rspec2" => "scope_rspec"}
         Config.load({:yaml => {:datadir => "/tmp"}})
         Config.load_backends
-        Backend::Yaml_backend.any_instance.stubs(:lookup).with("rspec", scope, nil, :priority, instance_of(RecursiveGuard)).returns("hiera_rspec")
+        Backend::Yaml_backend.any_instance.stubs(:lookup).with("rspec", scope, nil, :priority, instance_of(Hash)).returns("hiera_rspec")
         Backend.parse_answer(input, scope).should == {"foo"=>"test_hiera_rspec_test", "bar"=>"test_scope_rspec_test"}
       end
 
@@ -408,7 +408,7 @@ class Hiera
         scope = {"rspec" => "scope_rspec"}
         Config.load({:yaml => {:datadir => "/tmp"}})
         Config.load_backends
-        Backend::Yaml_backend.any_instance.stubs(:lookup).with("rspec", scope, nil, :priority, instance_of(RecursiveGuard)).returns("hiera_rspec")
+        Backend::Yaml_backend.any_instance.stubs(:lookup).with("rspec", scope, nil, :priority, instance_of(Hash)).returns("hiera_rspec")
         Backend.parse_answer(input, scope).should == "test_hiera_rspec_test_scope_rspec"
       end
 
@@ -470,7 +470,7 @@ class Hiera
         Config.load({:yaml => {:datadir => "/tmp"}})
         Config.load_backends
 
-        Backend::Yaml_backend.any_instance.expects(:lookup).with("key", {}, nil, nil, nil).returns("answer")
+        Backend::Yaml_backend.any_instance.expects(:lookup).with("key", {}, nil, nil, instance_of(Hash)).returns("answer")
 
         Backend.lookup("key", "default", {}, nil, nil).should == "answer"
       end
@@ -479,9 +479,9 @@ class Hiera
         Config.load({:yaml => {:datadir => "/tmp"}})
         Config.load_backends
 
-        Backend::Yaml_backend.any_instance.expects(:lookup).with("stringval", {}, nil, nil, nil).returns("string")
-        Backend::Yaml_backend.any_instance.expects(:lookup).with("boolval", {}, nil, nil, nil).returns(false)
-        Backend::Yaml_backend.any_instance.expects(:lookup).with("numericval", {}, nil, nil, nil).returns(1)
+        Backend::Yaml_backend.any_instance.expects(:lookup).with("stringval", {}, nil, nil, instance_of(Hash)).returns("string")
+        Backend::Yaml_backend.any_instance.expects(:lookup).with("boolval", {}, nil, nil, instance_of(Hash)).returns(false)
+        Backend::Yaml_backend.any_instance.expects(:lookup).with("numericval", {}, nil, nil, instance_of(Hash)).returns(1)
 
         Backend.lookup("stringval", "default", {}, nil, nil).should == "string"
         Backend.lookup("boolval", "default", {}, nil, nil).should == false
@@ -563,7 +563,7 @@ class Hiera
         Config.load_backends
 
         Backend.expects(:resolve_answer).with("test_test", :priority).returns("parsed")
-        Backend::Yaml_backend.any_instance.expects(:lookup).with("key", {"rspec" => "test"}, nil, :priority, nil).returns("test_test")
+        Backend::Yaml_backend.any_instance.expects(:lookup).with("key", {"rspec" => "test"}, nil, :priority, instance_of(Hash)).returns("test_test")
 
         Backend.lookup("key", "test_%{rspec}", {"rspec" => "test"}, nil, :priority).should == "parsed"
       end
@@ -572,7 +572,7 @@ class Hiera
         Config.load({:yaml => {:datadir => "/tmp"}})
         Config.load_backends
 
-        Backend::Yaml_backend.any_instance.expects(:lookup).with("key", {"rspec" => "test"}, nil, nil, nil)
+        Backend::Yaml_backend.any_instance.expects(:lookup).with("key", {"rspec" => "test"}, nil, nil, instance_of(Hash))
 
         Backend.lookup("key", "test_%{rspec}", {"rspec" => "test"}, nil, nil).should == "test_test"
       end
@@ -580,42 +580,42 @@ class Hiera
       it "keeps string default data as a string" do
         Config.load({:yaml => {:datadir => "/tmp"}})
         Config.load_backends
-        Backend::Yaml_backend.any_instance.expects(:lookup).with("key", {}, nil, nil, nil)
+        Backend::Yaml_backend.any_instance.expects(:lookup).with("key", {}, nil, nil, instance_of(Hash))
         Backend.lookup("key", "test", {}, nil, nil).should == "test"
       end
 
       it "keeps array default data as an array" do
         Config.load({:yaml => {:datadir => "/tmp"}})
         Config.load_backends
-        Backend::Yaml_backend.any_instance.expects(:lookup).with("key", {}, nil, :array, nil)
+        Backend::Yaml_backend.any_instance.expects(:lookup).with("key", {}, nil, :array, instance_of(Hash))
         Backend.lookup("key", ["test"], {}, nil, :array).should == ["test"]
       end
 
       it "keeps hash default data as a hash" do
         Config.load({:yaml => {:datadir => "/tmp"}})
         Config.load_backends
-        Backend::Yaml_backend.any_instance.expects(:lookup).with("key", {}, nil, :hash, nil)
+        Backend::Yaml_backend.any_instance.expects(:lookup).with("key", {}, nil, :hash, instance_of(Hash))
         Backend.lookup("key", {"test" => "value"}, {}, nil, :hash).should == {"test" => "value"}
       end
 
       it 'can use qualified key to lookup value in hash' do
         Config.load({:yaml => {:datadir => '/tmp'}})
         Config.load_backends
-        Backend::Yaml_backend.any_instance.expects(:lookup).with('key', {}, nil, nil, nil).returns({ 'test' => 'value'})
+        Backend::Yaml_backend.any_instance.expects(:lookup).with('key', {}, nil, nil, instance_of(Hash)).returns({ 'test' => 'value'})
         Backend.lookup('key.test', 'dflt', {}, nil, nil).should == 'value'
       end
 
       it 'can use qualified key to lookup value in array' do
         Config.load({:yaml => {:datadir => '/tmp'}})
         Config.load_backends
-        Backend::Yaml_backend.any_instance.expects(:lookup).with('key', {}, nil, nil, nil).returns([ 'first', 'second'])
+        Backend::Yaml_backend.any_instance.expects(:lookup).with('key', {}, nil, nil, instance_of(Hash)).returns([ 'first', 'second'])
         Backend.lookup('key.1', 'dflt', {}, nil, nil).should == 'second'
       end
 
       it 'will fail when qualified key is partially found but not expected hash' do
         Config.load({:yaml => {:datadir => '/tmp'}})
         Config.load_backends
-        Backend::Yaml_backend.any_instance.expects(:lookup).with('key', {}, nil, nil, nil).returns(['value 1', 'value 2'])
+        Backend::Yaml_backend.any_instance.expects(:lookup).with('key', {}, nil, nil, instance_of(Hash)).returns(['value 1', 'value 2'])
         expect do
           Backend.lookup('key.test', 'dflt', {}, nil, nil)
         end.to raise_error(Exception, /^Hiera type mismatch:/)
@@ -636,14 +636,14 @@ class Hiera
       it 'will succeed when qualified key used with resolution_type :priority' do
         Config.load({:yaml => {:datadir => '/tmp'}})
         Config.load_backends
-        Backend::Yaml_backend.any_instance.expects(:lookup).with('key', {}, nil, :priority, nil).returns({ 'test' => 'value'})
+        Backend::Yaml_backend.any_instance.expects(:lookup).with('key', {}, nil, :priority, instance_of(Hash)).returns({ 'test' => 'value'})
         Backend.lookup('key.test', 'dflt', {}, nil, :priority).should == 'value'
       end
 
       it 'will fail when qualified key is partially found but not expected array' do
         Config.load({:yaml => {:datadir => '/tmp'}})
         Config.load_backends
-        Backend::Yaml_backend.any_instance.expects(:lookup).with('key', {}, nil, nil, nil).returns({ 'test' => 'value'})
+        Backend::Yaml_backend.any_instance.expects(:lookup).with('key', {}, nil, nil, instance_of(Hash)).returns({ 'test' => 'value'})
         expect do
           Backend.lookup('key.2', 'dflt', {}, nil, nil)
         end.to raise_error(Exception, /^Hiera type mismatch:/)
@@ -652,14 +652,14 @@ class Hiera
       it 'will not fail when qualified key is partially not found' do
         Config.load({:yaml => {:datadir => '/tmp'}})
         Config.load_backends
-        Backend::Yaml_backend.any_instance.expects(:lookup).with('key', {}, nil, nil, nil).returns(nil)
+        Backend::Yaml_backend.any_instance.expects(:lookup).with('key', {}, nil, nil, instance_of(Hash)).returns(nil)
         Backend.lookup('key.test', 'dflt', {}, nil, nil).should == 'dflt'
       end
 
       it 'will not fail when qualified key is array index out of bounds' do
         Config.load({:yaml => {:datadir => '/tmp'}})
         Config.load_backends
-        Backend::Yaml_backend.any_instance.expects(:lookup).with('key', {}, nil, nil, nil).returns(['value 1', 'value 2'])
+        Backend::Yaml_backend.any_instance.expects(:lookup).with('key', {}, nil, nil, instance_of(Hash)).returns(['value 1', 'value 2'])
         Backend.lookup('key.33', 'dflt', {}, nil, nil).should == 'dflt'
       end
 
@@ -675,7 +675,7 @@ class Hiera
         Config.load({:yaml => {:datadir => '/tmp'}})
         Config.load_backends
         scope = { 'some' => { 'test' => 'value'}}
-        Backend::Yaml_backend.any_instance.expects(:lookup).with('key', scope, nil, nil, nil)
+        Backend::Yaml_backend.any_instance.expects(:lookup).with('key', scope, nil, nil, instance_of(Hash))
         Backend.lookup('key.notfound', '%{some.test}', scope, nil, nil).should == 'value'
       end
 


### PR DESCRIPTION
The existing implementation of hiera interpolation did not utilize the
order override parameter of lookup. If an interpolated variable was
expected to be looked up in the overridden datasource it would instead
only be looked up in the configured datasources.

This patch passes the order_override parameter down the call stack to
the hiera_interpolate method of the Hiera::Interpolate class. This
method then in turn passes the order_override parameter back into the
Hiera::Backend lookup method. Thereby allowing the overridden datasource
to be searched for lookup values.