### PR TITLE
(HI-327) Set acceptance tests to run on agent role

### DIFF
--- a/acceptance_tests/tests/yaml_backend/00-setup.rb
+++ b/acceptance_tests/tests/yaml_backend/00-setup.rb
@@ -1,6 +1,7 @@
 test_name "Hiera setup for YAML backend"
 
-apply_manifest_on master, <<-PP
+agents.each do |agent|
+  apply_manifest_on agent, <<-PP
 file { '/etc/hiera.yaml':
   ensure  => present,
   content => '---
@@ -24,3 +25,4 @@ file { '/etc/puppet/hieradata':
   force   => true,
 }
 PP
+end

--- a/acceptance_tests/tests/yaml_backend/00-setup.rb
+++ b/acceptance_tests/tests/yaml_backend/00-setup.rb
@@ -2,7 +2,7 @@ test_name "Hiera setup for YAML backend"
 
 agents.each do |agent|
   apply_manifest_on agent, <<-PP
-file { '/etc/hiera.yaml':
+file { '#{agent['hieraconf']}':
   ensure  => present,
   content => '---
     :backends:
@@ -14,11 +14,11 @@ file { '/etc/hiera.yaml':
       - "global"
 
     :yaml:
-      :datadir: "/etc/puppet/hieradata"
+      :datadir: "#{agent['hieradatadir']}"
   '
 }
 
-file { '/etc/puppet/hieradata':
+file { '#{agent['hieradatadir']}':
   ensure  => directory,
   recurse => true,
   purge   => true,

--- a/acceptance_tests/tests/yaml_backend/01-lookup_data_without_a_key.rb
+++ b/acceptance_tests/tests/yaml_backend/01-lookup_data_without_a_key.rb
@@ -2,8 +2,10 @@ test_name "Lookup data without a key"
 
 step "Try to lookup data without specifying a key"
 
-on master, hiera(""), :acceptable_exit_codes => [1] do
+agents.each do |agent|
+on agent, hiera(""), :acceptable_exit_codes => [1] do
   assert_output <<-OUTPUT
     STDERR> Please supply a data item to look up
   OUTPUT
+end
 end

--- a/acceptance_tests/tests/yaml_backend/02-lookup_data_with_no_options.rb
+++ b/acceptance_tests/tests/yaml_backend/02-lookup_data_with_no_options.rb
@@ -4,7 +4,7 @@ begin test_name "Lookup data using the default options"
 
     step 'Setup'
       apply_manifest_on agent, <<-PP
-        file { '/etc/puppet/hieradata':
+        file { '#{agent['hieradatadir']}':
           ensure  => directory,
           recurse => true,
           purge   => true,
@@ -13,7 +13,7 @@ begin test_name "Lookup data using the default options"
     PP
 
       apply_manifest_on agent, <<-PP
-        file { '/etc/puppet/hieradata/global.yaml':
+        file { '#{agent['hieradatadir']}/global.yaml':
           ensure  => present,
           content => "---
             http_port: 8080

--- a/acceptance_tests/tests/yaml_backend/02-lookup_data_with_no_options.rb
+++ b/acceptance_tests/tests/yaml_backend/02-lookup_data_with_no_options.rb
@@ -1,48 +1,52 @@
 begin test_name "Lookup data using the default options"
 
-step 'Setup'
-apply_manifest_on master, <<-PP
-file { '/etc/puppet/hieradata/global.yaml':
-  ensure  => present,
-  content => "---
-    http_port: 8080
-    ntp_servers: ['0.ntp.puppetlabs.com', '1.ntp.puppetlabs.com']
-    users:
-      pete:
-        uid: 2000
-      tom:
-        uid: 2001
-  "
-}
-PP
+  agents.each do |agent|
 
-step "Try to lookup string data"
-on master, hiera("http_port"), :acceptable_exit_codes => [0] do
-  assert_output <<-OUTPUT
-    STDOUT> 8080
-  OUTPUT
-end
+    step 'Setup'
+      apply_manifest_on agent, <<-PP
+        file { '/etc/puppet/hieradata':
+          ensure  => directory,
+          recurse => true,
+          purge   => true,
+          force   => true,
+        }
+    PP
 
-step "Try to lookup array data"
-on master, hiera("ntp_servers"), :acceptable_exit_codes => [0] do
-  assert_output <<-OUTPUT
-    STDOUT> ["0.ntp.puppetlabs.com", "1.ntp.puppetlabs.com"]
-  OUTPUT
-end
+      apply_manifest_on agent, <<-PP
+        file { '/etc/puppet/hieradata/global.yaml':
+          ensure  => present,
+          content => "---
+            http_port: 8080
+            ntp_servers: ['0.ntp.puppetlabs.com', '1.ntp.puppetlabs.com']
+            users:
+              pete:
+                uid: 2000
+              tom:
+                uid: 2001
+          "
+        }
+    PP
 
-step "Try to lookup hash data"
-on master, hiera("users"), :acceptable_exit_codes => [0] do
-  assert_match /tom[^}]+"uid"=>2001}/, result.output
-  assert_match /pete[^}]+"uid"=>2000}/, result.output
-end
+    step "Try to lookup string data"
+      on agent, hiera("http_port"), :acceptable_exit_codes => [0] do
+        assert_output <<-OUTPUT
+          STDOUT> 8080
+        OUTPUT
+      end
 
-ensure step "Teardown"
-apply_manifest_on master, <<-PP
-file { '/etc/puppet/hieradata':
-  ensure  => directory,
-  recurse => true,
-  purge   => true,
-  force   => true,
-}
-PP
+      step "Try to lookup array data"
+      on agent, hiera("ntp_servers"), :acceptable_exit_codes => [0] do
+        assert_output <<-OUTPUT
+          STDOUT> ["0.ntp.puppetlabs.com", "1.ntp.puppetlabs.com"]
+        OUTPUT
+      end
+
+      step "Try to lookup hash data"
+      on agent, hiera("users"), :acceptable_exit_codes => [0] do
+        assert_match /tom[^}]+"uid"=>2001}/, result.output
+        assert_match /pete[^}]+"uid"=>2000}/, result.output
+      end
+
+  end
+
 end

--- a/acceptance_tests/tests/yaml_backend/03-lookup_data_with_a_scope.rb
+++ b/acceptance_tests/tests/yaml_backend/03-lookup_data_with_a_scope.rb
@@ -4,7 +4,7 @@ begin test_name "Lookup data with a scope"
 
     teardown do
       apply_manifest_on agent, <<-PP
-      file { '/etc/puppet/hieradata':
+      file { '#{agent['hieradatadir']}':
         ensure  => directory,
         recurse => true,
         purge   => true,
@@ -17,7 +17,7 @@ begin test_name "Lookup data with a scope"
 
     step 'Setup'
       apply_manifest_on agent, <<-PP
-      file { '/etc/puppet/hieradata/global.yaml':
+      file { '#{agent['hieradatadir']}/global.yaml':
         ensure  => present,
         content => "---
           http_port: 8080
@@ -34,7 +34,7 @@ begin test_name "Lookup data with a scope"
         "
       }
 
-      file { '/etc/puppet/hieradata/production.yaml':
+      file { '#{agent['hieradatadir']}/production.yaml':
         ensure  => present,
         content => "---
           http_port: 9090

--- a/acceptance_tests/tests/yaml_backend/03-lookup_data_with_a_scope.rb
+++ b/acceptance_tests/tests/yaml_backend/03-lookup_data_with_a_scope.rb
@@ -1,62 +1,68 @@
 begin test_name "Lookup data with a scope"
 
-step 'Setup'
-apply_manifest_on master, <<-PP
-file { '/etc/puppet/hieradata/global.yaml':
-  ensure  => present,
-  content => "---
-    http_port: 8080
-    ntp_servers: ['0.ntp.puppetlabs.com', '1.ntp.puppetlabs.com']
-    users:
-      pete:
-        uid: 2000
-        gid: 2000
-        shell: '/bin/bash'
-      tom:
-        uid: 2001
-        gid: 2001
-        shell: '/bin/bash'
-  "
-}
+  agents.each do |agent|
 
-file { '/etc/puppet/hieradata/production.yaml':
-  ensure  => present,
-  content => "---
-    http_port: 9090
-    monitor: enable
-    ntp_servers: ['0.ntp.puppetlabs.com', '1.ntp.puppetlabs.com']
-  "
-}
+    teardown do
+      apply_manifest_on agent, <<-PP
+      file { '/etc/puppet/hieradata':
+        ensure  => directory,
+        recurse => true,
+        purge   => true,
+        force   => true,
+      }
+      file { '/etc/puppet/scope.yaml': ensure => absent }
+      file { '/etc/puppet/scope.json': ensure => absent }
+      PP
+    end
 
-file { '/etc/puppet/scope.yaml':
-  ensure  => present,
-  content => "---
-    environment: production
-  "
-}
-PP
+    step 'Setup'
+      apply_manifest_on agent, <<-PP
+      file { '/etc/puppet/hieradata/global.yaml':
+        ensure  => present,
+        content => "---
+          http_port: 8080
+          ntp_servers: ['0.ntp.puppetlabs.com', '1.ntp.puppetlabs.com']
+          users:
+            pete:
+              uid: 2000
+              gid: 2000
+              shell: '/bin/bash'
+            tom:
+              uid: 2001
+              gid: 2001
+              shell: '/bin/bash'
+        "
+      }
 
-step "Try to lookup string data using a scope from a yaml file"
-on master, hiera('monitor', '--yaml', '/etc/puppet/scope.yaml'),
-  :acceptable_exit_codes => [0] do
-  assert_output <<-OUTPUT
-    STDOUT> enable
-  OUTPUT
-end
+      file { '/etc/puppet/hieradata/production.yaml':
+        ensure  => present,
+        content => "---
+          http_port: 9090
+          monitor: enable
+          ntp_servers: ['0.ntp.puppetlabs.com', '1.ntp.puppetlabs.com']
+        "
+      }
 
-# TODO: Add a test for supplying scope from a json file.
-# We need to workout the requirement on the json gem.
-step "Try to lookup string data using a scope from a yaml file"
+      file { '/etc/puppet/scope.yaml':
+        ensure  => present,
+        content => "---
+          environment: production
+        "
+      }
+      PP
 
-ensure step "Teardown"
-apply_manifest_on master, <<-PP
-file { '/etc/puppet/hieradata':
-  ensure  => directory,
-  recurse => true,
-  purge   => true,
-  force   => true,
-}
-file { '/etc/puppet/scope.yaml': ensure => absent }
-file { '/etc/puppet/scope.json': ensure => absent }
-PP
+    step "Try to lookup string data using a scope from a yaml file"
+      on agent, hiera('monitor', '--yaml', '/etc/puppet/scope.yaml'),
+        :acceptable_exit_codes => [0] do
+        assert_output <<-OUTPUT
+          STDOUT> enable
+        OUTPUT
+      end
+
+    # TODO: Add a test for supplying scope from a json file.
+    # We need to workout the requirement on the json gem.
+    step "Try to lookup string data using a scope from a yaml file"
+
+  end
+
 end

--- a/acceptance_tests/tests/yaml_backend/04-lookup_data_with_array_search.rb
+++ b/acceptance_tests/tests/yaml_backend/04-lookup_data_with_array_search.rb
@@ -1,46 +1,52 @@
 begin test_name "Lookup data with Array search"
 
-step 'Setup'
-apply_manifest_on master, <<-PP
-file { '/etc/puppet/hieradata/production.yaml':
-  ensure  => present,
-  content => "---
-    ntpservers: ['production.ntp.puppetlabs.com']
-  "
-}
+  agents.each do |agent|
 
-file { '/etc/puppet/hieradata/global.yaml':
-  ensure  => present,
-  content => "---
-    ntpservers: ['global.ntp.puppetlabs.com']
-  "
-}
+    teardown do
+      apply_manifest_on agent, <<-PP
+      file { '/etc/puppet/hieradata':
+        ensure  => directory,
+        recurse => true,
+        purge   => true,
+        force   => true,
+      }
+      file { '/etc/puppet/scope.yaml': ensure => absent }
+      file { '/etc/puppet/scope.json': ensure => absent }
+      PP
+    end
 
-file { '/etc/puppet/scope.yaml':
-  ensure  => present,
-  content => "---
-    environment: production
-  "
-}
-PP
+    step 'Setup'
+      apply_manifest_on agent, <<-PP
+      file { '/etc/puppet/hieradata/production.yaml':
+        ensure  => present,
+        content => "---
+          ntpservers: ['production.ntp.puppetlabs.com']
+        "
+      }
 
-step "Try to lookup data using array search"
-on master, hiera('ntpservers', '--yaml', '/etc/puppet/scope.yaml', '--array'),
-  :acceptable_exit_codes => [0] do
-  assert_output <<-OUTPUT
-    STDOUT> ["production.ntp.puppetlabs.com", "global.ntp.puppetlabs.com"]
-  OUTPUT
-end
+      file { '/etc/puppet/hieradata/global.yaml':
+        ensure  => present,
+        content => "---
+          ntpservers: ['global.ntp.puppetlabs.com']
+        "
+      }
 
-ensure step "Teardown"
-apply_manifest_on master, <<-PP
-file { '/etc/puppet/hieradata':
-  ensure  => directory,
-  recurse => true,
-  purge   => true,
-  force   => true,
-}
-file { '/etc/puppet/scope.yaml': ensure => absent }
-file { '/etc/puppet/scope.json': ensure => absent }
-PP
+      file { '/etc/puppet/scope.yaml':
+        ensure  => present,
+        content => "---
+          environment: production
+        "
+      }
+      PP
+
+    step "Try to lookup data using array search"
+      on agent, hiera('ntpservers', '--yaml', '/etc/puppet/scope.yaml', '--array'),
+        :acceptable_exit_codes => [0] do
+        assert_output <<-OUTPUT
+          STDOUT> ["production.ntp.puppetlabs.com", "global.ntp.puppetlabs.com"]
+        OUTPUT
+      end
+
+  end
+
 end

--- a/acceptance_tests/tests/yaml_backend/04-lookup_data_with_array_search.rb
+++ b/acceptance_tests/tests/yaml_backend/04-lookup_data_with_array_search.rb
@@ -4,7 +4,7 @@ begin test_name "Lookup data with Array search"
 
     teardown do
       apply_manifest_on agent, <<-PP
-      file { '/etc/puppet/hieradata':
+      file { '#{agent['hieradatadir']}':
         ensure  => directory,
         recurse => true,
         purge   => true,
@@ -17,14 +17,14 @@ begin test_name "Lookup data with Array search"
 
     step 'Setup'
       apply_manifest_on agent, <<-PP
-      file { '/etc/puppet/hieradata/production.yaml':
+      file { '#{agent['hieradatadir']}/production.yaml':
         ensure  => present,
         content => "---
           ntpservers: ['production.ntp.puppetlabs.com']
         "
       }
 
-      file { '/etc/puppet/hieradata/global.yaml':
+      file { '#{agent['hieradatadir']}/global.yaml':
         ensure  => present,
         content => "---
           ntpservers: ['global.ntp.puppetlabs.com']

--- a/acceptance_tests/tests/yaml_backend/05-lookup_data_with_hash_search.rb
+++ b/acceptance_tests/tests/yaml_backend/05-lookup_data_with_hash_search.rb
@@ -1,49 +1,55 @@
 begin test_name "Lookup data with Hash search"
 
-step 'Setup'
-apply_manifest_on master, <<-PP
-file { '/etc/puppet/hieradata/production.yaml':
-  ensure  => present,
-  content => "---
-    users:
-      joe:
-        uid: 1000
-  "
-}
+  agents.each do |agent|
 
-file { '/etc/puppet/hieradata/global.yaml':
-  ensure  => present,
-  content => "---
-    users:
-      pete:
-        uid: 1001
-  "
-}
+    teardown do
+      apply_manifest_on agent, <<-PP
+      file { '/etc/puppet/hieradata':
+        ensure  => directory,
+        recurse => true,
+        purge   => true,
+        force   => true,
+      }
+      file { '/etc/puppet/scope.yaml': ensure => absent }
+      file { '/etc/puppet/scope.json': ensure => absent }
+      PP
+    end
 
-file { '/etc/puppet/scope.yaml':
-  ensure  => present,
-  content => "---
-    environment: production
-  "
-}
-PP
+    step 'Setup'
+      apply_manifest_on agent, <<-PP
+      file { '/etc/puppet/hieradata/production.yaml':
+        ensure  => present,
+        content => "---
+          users:
+            joe:
+              uid: 1000
+        "
+      }
 
-step "Try to lookup data using hash search"
-on master, hiera('users', '--yaml', '/etc/puppet/scope.yaml', '--hash'),
-  :acceptable_exit_codes => [0] do
-  assert_match /joe[^}]+"uid"=>1000}/, result.output
-  assert_match /pete[^}]+"uid"=>1001}/, result.output
-end
+      file { '/etc/puppet/hieradata/global.yaml':
+        ensure  => present,
+        content => "---
+          users:
+            pete:
+              uid: 1001
+        "
+      }
 
-ensure step "Teardown"
-apply_manifest_on master, <<-PP
-file { '/etc/puppet/hieradata':
-  ensure  => directory,
-  recurse => true,
-  purge   => true,
-  force   => true,
-}
-file { '/etc/puppet/scope.yaml': ensure => absent }
-file { '/etc/puppet/scope.json': ensure => absent }
-PP
+      file { '/etc/puppet/scope.yaml':
+        ensure  => present,
+        content => "---
+          environment: production
+        "
+      }
+      PP
+
+    step "Try to lookup data using hash search"
+      on agent, hiera('users', '--yaml', '/etc/puppet/scope.yaml', '--hash'),
+        :acceptable_exit_codes => [0] do
+        assert_match /joe[^}]+"uid"=>1000}/, result.output
+        assert_match /pete[^}]+"uid"=>1001}/, result.output
+      end
+
+  end
+
 end

--- a/acceptance_tests/tests/yaml_backend/05-lookup_data_with_hash_search.rb
+++ b/acceptance_tests/tests/yaml_backend/05-lookup_data_with_hash_search.rb
@@ -4,7 +4,7 @@ begin test_name "Lookup data with Hash search"
 
     teardown do
       apply_manifest_on agent, <<-PP
-      file { '/etc/puppet/hieradata':
+      file { '#{agent['hieradatadir']}':
         ensure  => directory,
         recurse => true,
         purge   => true,
@@ -17,7 +17,7 @@ begin test_name "Lookup data with Hash search"
 
     step 'Setup'
       apply_manifest_on agent, <<-PP
-      file { '/etc/puppet/hieradata/production.yaml':
+      file { '#{agent['hieradatadir']}/production.yaml':
         ensure  => present,
         content => "---
           users:
@@ -26,7 +26,7 @@ begin test_name "Lookup data with Hash search"
         "
       }
 
-      file { '/etc/puppet/hieradata/global.yaml':
+      file { '#{agent['hieradatadir']}/global.yaml':
         ensure  => present,
         content => "---
           users:


### PR DESCRIPTION
This commit changes the node role that the acceptance tests run on from
`master` to `agent`.

This change is required in order for the tests to run test configurations
using the All In One agent packaging. The AIO testing applies directly to
agent nodes, and since Hiera functionality does not require a master, pinning
the test execution to the master role should be generalized to the agent.