### PR TITLE
(maint) Don't Parameterize the hiera CLI config

### DIFF
--- a/acceptance_tests/tests/yaml_backend/00-setup.rb
+++ b/acceptance_tests/tests/yaml_backend/00-setup.rb
@@ -2,7 +2,7 @@ test_name "Hiera setup for YAML backend"
 
 agents.each do |agent|
   apply_manifest_on agent, <<-PP
-file { '#{agent['hieraconf']}':
+file { '/etc/hiera.yaml':
   ensure  => present,
   content => '---
     :backends:


### PR DESCRIPTION
We parameterized most of the hard coded paths, unfortunately we don't
have a parameterization for the config hiera uses when it is ran as a
CLI tool (because it uses a different one than when it's ran as a
library, natch). This reverts the functionality of the setup step to
create the hiera.yaml file needed by the rest of the tests in the
/etc/hiera.yaml location that the CLI version of hiera expects.