### PR TITLE
(HI-328) Prevent interpolation recursion

### DIFF
--- a/lib/hiera/backend/json_backend.rb
+++ b/lib/hiera/backend/json_backend.rb
@@ -9,7 +9,7 @@ class Hiera
         @cache = cache || Filecache.new
       end
 
-      def lookup(key, scope, order_override, resolution_type)
+      def lookup(key, scope, order_override, resolution_type, recurse_guard)
         answer = nil
 
         Hiera.debug("Looking up #{key} in JSON backend")
@@ -33,7 +33,7 @@ class Hiera
           # the array
           #
           # for priority searches we break after the first found data item
-          new_answer = Backend.parse_answer(data[key], scope)
+          new_answer = Backend.parse_answer(data[key], scope, nil, recurse_guard)
           case resolution_type
           when :array
             raise Exception, "Hiera type mismatch for key '#{key}': expected Array and got #{new_answer.class}" unless new_answer.kind_of? Array or new_answer.kind_of? String

--- a/lib/hiera/backend/yaml_backend.rb
+++ b/lib/hiera/backend/yaml_backend.rb
@@ -8,7 +8,7 @@ class Hiera
         @cache = cache || Filecache.new
       end
 
-      def lookup(key, scope, order_override, resolution_type)
+      def lookup(key, scope, order_override, resolution_type, recurse_guard)
         answer = nil
 
         Hiera.debug("Looking up #{key} in YAML backend")
@@ -32,7 +32,7 @@ class Hiera
           # the array
           #
           # for priority searches we break after the first found data item
-          new_answer = Backend.parse_answer(data[key], scope)
+          new_answer = Backend.parse_answer(data[key], scope, nil, recurse_guard)
           case resolution_type
           when :array
             raise Exception, "Hiera type mismatch for key '#{key}': expected Array and got #{new_answer.class}" unless new_answer.kind_of? Array or new_answer.kind_of? String

--- a/lib/hiera/interpolate.rb
+++ b/lib/hiera/interpolate.rb
@@ -9,12 +9,13 @@ class Hiera::Interpolate
     INTERPOLATION = /%\{([^\}]*)\}/
     METHOD_INTERPOLATION = /%\{(scope|hiera|literal|alias)\(['"]([^"']*)["']\)\}/
 
-    def interpolate(data, scope, extra_data)
+    def interpolate(data, scope, extra_data, recurse_guard)
       if data.is_a?(String)
         # Wrapping do_interpolation in a gsub block ensures we process
         # each interpolation site in isolation using separate recursion guards.
+        recurse_guard ||= Hiera::RecursiveGuard.new
         data.gsub(INTERPOLATION) do |match|
-          interp_val = do_interpolation(match, Hiera::RecursiveGuard.new, scope, extra_data)
+          interp_val = do_interpolation(match, recurse_guard, scope, extra_data)
 
           # Get interp method in case we are aliasing
           if data.is_a?(String) && (match = data.match(INTERPOLATION))
@@ -43,7 +44,7 @@ class Hiera::Interpolate
         interpolation_variable = match[1]
         recurse_guard.check(interpolation_variable) do
           interpolate_method, key = get_interpolation_method_and_key(data)
-          interpolated_data = send(interpolate_method, data, key, scope, extra_data)
+          interpolated_data = send(interpolate_method, data, key, scope, extra_data, recurse_guard)
 
           # Halt recursion if we encounter a literal.
           return interpolated_data if interpolate_method == :literal_interpolate
@@ -70,25 +71,25 @@ class Hiera::Interpolate
     end
     private :get_interpolation_method_and_key
 
-    def scope_interpolate(data, key, scope, extra_data)
+    def scope_interpolate(data, key, scope, extra_data, recurse_guard)
       segments = key.split('.')
       value = Hiera::Backend.qualified_lookup(segments, scope)
       value.nil? ? Hiera::Backend.qualified_lookup(segments, extra_data) : value
     end
     private :scope_interpolate
 
-    def hiera_interpolate(data, key, scope, extra_data)
-      Hiera::Backend.lookup(key, nil, scope, nil, :priority)
+    def hiera_interpolate(data, key, scope, extra_data, recurse_guard)
+      Hiera::Backend.lookup(key, nil, scope, nil, :priority, recurse_guard)
     end
     private :hiera_interpolate
 
-    def literal_interpolate(data, key, scope, extra_data)
+    def literal_interpolate(data, key, scope, extra_data, recurse_guard)
       key
     end
     private :literal_interpolate
 
-    def alias_interpolate(data, key, scope, extra_data)
-      Hiera::Backend.lookup(key, nil, scope, nil, :priority)
+    def alias_interpolate(data, key, scope, extra_data, recurse_guard)
+      Hiera::Backend.lookup(key, nil, scope, nil, :priority, recurse_guard)
     end
     private :alias_interpolate
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,6 +28,11 @@ RSpec.configure do |config|
   end
 end
 
+# So everyone else doesn't have to include this base constant.
+module HieraSpec
+  FIXTURE_DIR = File.join(dir = File.expand_path(File.dirname(__FILE__)), 'unit', 'fixtures') unless defined?(FIXTURE_DIR)
+end
+
 # In ruby 1.8.5 Dir does not have mktmpdir defined, so this monkey patches
 # Dir to include the 1.8.7 definition of that method if it isn't already defined.
 # Method definition borrowed from ruby-1.8.7-p357/lib/ruby/1.8/tmpdir.rb

--- a/spec/unit/backend/json_backend_spec.rb
+++ b/spec/unit/backend/json_backend_spec.rb
@@ -25,7 +25,7 @@ class Hiera
           Backend.expects(:datafile).with(:json, {}, "one", "json").returns(nil)
           Backend.expects(:datafile).with(:json, {}, "two", "json").returns(nil)
 
-          @backend.lookup("key", {}, nil, :priority)
+          @backend.lookup("key", {}, nil, :priority, nil)
         end
 
         it "should retain the data types found in data files" do
@@ -35,9 +35,9 @@ class Hiera
 
           @cache.expects(:read_file).with("/nonexisting/one.json", Hash).returns({"stringval" => "string", "boolval" => true, "numericval" => 1}).times(3)
 
-          @backend.lookup("stringval", {}, nil, :priority).should == "string"
-          @backend.lookup("boolval", {}, nil, :priority).should == true
-          @backend.lookup("numericval", {}, nil, :priority).should == 1
+          @backend.lookup("stringval", {}, nil, :priority, nil).should == "string"
+          @backend.lookup("boolval", {}, nil, :priority, nil).should == true
+          @backend.lookup("numericval", {}, nil, :priority, nil).should == 1
         end
 
         it "should pick data earliest source that has it for priority searches" do
@@ -49,12 +49,12 @@ class Hiera
           File.stubs(:exist?).with("/nonexisting/one.json").returns(true)
           @cache.expects(:read_file).with("/nonexisting/one.json", Hash).returns({"key" => "test_%{rspec}"})
 
-          @backend.lookup("key", scope, nil, :priority).should == "test_test"
+          @backend.lookup("key", scope, nil, :priority, nil).should == "test_test"
         end
 
         it "should build an array of all data sources for array searches" do
           Hiera::Backend.stubs(:empty_answer).returns([])
-          Backend.stubs(:parse_answer).with('answer', {}).returns("answer")
+          Backend.stubs(:parse_answer).with('answer', {}, nil, nil).returns("answer")
           Backend.expects(:datafile).with(:json, {}, "one", "json").returns("/nonexisting/one.json")
           Backend.expects(:datafile).with(:json, {}, "two", "json").returns("/nonexisting/two.json")
 
@@ -66,18 +66,18 @@ class Hiera
           @cache.expects(:read_file).with("/nonexisting/one.json", Hash).returns({"key" => "answer"})
           @cache.expects(:read_file).with("/nonexisting/two.json", Hash).returns({"key" => "answer"})
 
-          @backend.lookup("key", {}, nil, :array).should == ["answer", "answer"]
+          @backend.lookup("key", {}, nil, :array, nil).should == ["answer", "answer"]
         end
 
         it "should parse the answer for scope variables" do
-          Backend.stubs(:parse_answer).with('test_%{rspec}', {'rspec' => 'test'}).returns("test_test")
+          Backend.stubs(:parse_answer).with('test_%{rspec}', {'rspec' => 'test'}, nil, nil).returns("test_test")
           Backend.expects(:datasources).yields("one")
           Backend.expects(:datafile).with(:json, {"rspec" => "test"}, "one", "json").returns("/nonexisting/one.json")
 
           File.expects(:exist?).with("/nonexisting/one.json").returns(true)
           @cache.expects(:read_file).with("/nonexisting/one.json", Hash).returns({"key" => "test_%{rspec}"})
 
-          @backend.lookup("key", {"rspec" => "test"}, nil, :priority).should == "test_test"
+          @backend.lookup("key", {"rspec" => "test"}, nil, :priority, nil).should == "test_test"
         end
       end
     end

--- a/spec/unit/backend/yaml_backend_spec.rb
+++ b/spec/unit/backend/yaml_backend_spec.rb
@@ -41,7 +41,7 @@ class Hiera
           Backend.expects(:datasourcefiles).with(:yaml, {}, "yaml", nil).yields(["one", "/nonexisting/one.yaml"])
           @cache.value = "---\nkey: answer"
 
-          @backend.lookup("key", {}, nil, :priority).should == "answer"
+          @backend.lookup("key", {}, nil, :priority, nil).should == "answer"
         end
 
         describe "handling unexpected YAML values" do
@@ -51,17 +51,17 @@ class Hiera
 
           it "returns nil when the YAML value is nil" do
             @cache.value = "---\n"
-            @backend.lookup("key", {}, nil, :priority).should be_nil
+            @backend.lookup("key", {}, nil, :priority, nil).should be_nil
           end
 
           it "returns nil when the YAML file is false" do
             @cache.value = ""
-            @backend.lookup("key", {}, nil, :priority).should be_nil
+            @backend.lookup("key", {}, nil, :priority, nil).should be_nil
           end
 
           it "raises a TypeError when the YAML value is not a hash" do
             @cache.value = "---\n[one, two, three]"
-            expect { @backend.lookup("key", {}, nil, :priority) }.to raise_error(TypeError)
+            expect { @backend.lookup("key", {}, nil, :priority, nil) }.to raise_error(TypeError)
           end
         end
 
@@ -70,7 +70,7 @@ class Hiera
           @cache.expects(:read_file).with("/nonexisting/one.yaml", Hash).returns({"key"=>"answer"})
           @cache.expects(:read_file).with("/nonexisting/two.yaml", Hash).returns({"key"=>"answer"})
 
-          @backend.lookup("key", {}, nil, :array).should == ["answer", "answer"]
+          @backend.lookup("key", {}, nil, :array, nil).should == ["answer", "answer"]
         end
 
         it "should ignore empty hash of data sources for hash searches" do
@@ -79,7 +79,7 @@ class Hiera
           @cache.expects(:read_file).with("/nonexisting/one.yaml", Hash).returns({})
           @cache.expects(:read_file).with("/nonexisting/two.yaml", Hash).returns({"key"=>{"a"=>"answer"}})
 
-          @backend.lookup("key", {}, nil, :hash).should == {"a" => "answer"}
+          @backend.lookup("key", {}, nil, :hash, nil).should == {"a" => "answer"}
         end
 
         it "should build a merged hash of data sources for hash searches" do
@@ -88,7 +88,7 @@ class Hiera
           @cache.expects(:read_file).with("/nonexisting/one.yaml", Hash).returns({"key"=>{"a"=>"answer"}})
           @cache.expects(:read_file).with("/nonexisting/two.yaml", Hash).returns({"key"=>{"b"=>"answer", "a"=>"wrong"}})
 
-          @backend.lookup("key", {}, nil, :hash).should == {"a" => "answer", "b" => "answer"}
+          @backend.lookup("key", {}, nil, :hash, nil).should == {"a" => "answer", "b" => "answer"}
         end
 
         it "should fail when trying to << a Hash" do
@@ -97,7 +97,7 @@ class Hiera
           @cache.expects(:read_file).with("/nonexisting/one.yaml", Hash).returns({"key"=>["a", "answer"]})
           @cache.expects(:read_file).with("/nonexisting/two.yaml", Hash).returns({"key"=>{"a"=>"answer"}})
 
-          expect {@backend.lookup("key", {}, nil, :array)}.to raise_error(Exception, "Hiera type mismatch for key 'key': expected Array and got Hash")
+          expect {@backend.lookup("key", {}, nil, :array, nil)}.to raise_error(Exception, "Hiera type mismatch for key 'key': expected Array and got Hash")
         end
 
         it "should fail when trying to merge an Array" do
@@ -106,7 +106,7 @@ class Hiera
           @cache.expects(:read_file).with("/nonexisting/one.yaml", Hash).returns({"key"=>{"a"=>"answer"}})
           @cache.expects(:read_file).with("/nonexisting/two.yaml", Hash).returns({"key"=>["a", "wrong"]})
 
-          expect { @backend.lookup("key", {}, nil, :hash) }.to raise_error(Exception, "Hiera type mismatch for key 'key': expected Hash and got Array")
+          expect { @backend.lookup("key", {}, nil, :hash, nil) }.to raise_error(Exception, "Hiera type mismatch for key 'key': expected Hash and got Array")
         end
 
         it "should parse the answer for scope variables" do
@@ -114,7 +114,7 @@ class Hiera
 
           @cache.expects(:read_file).with("/nonexisting/one.yaml", Hash).returns({"key"=>"test_%{rspec}"})
 
-          @backend.lookup("key", {"rspec" => "test"}, nil, :priority).should == "test_test"
+          @backend.lookup("key", {"rspec" => "test"}, nil, :priority, nil).should == "test_test"
         end
 
         it "should retain datatypes found in yaml files" do
@@ -123,9 +123,9 @@ class Hiera
 
           @cache.value = "---\nstringval: 'string'\nboolval: true\nnumericval: 1"
 
-          @backend.lookup("stringval", {}, nil, :priority).should == "string"
-          @backend.lookup("boolval", {}, nil, :priority).should == true
-          @backend.lookup("numericval", {}, nil, :priority).should == 1
+          @backend.lookup("stringval", {}, nil, :priority, nil).should == "string"
+          @backend.lookup("boolval", {}, nil, :priority, nil).should == true
+          @backend.lookup("numericval", {}, nil, :priority, nil).should == 1
         end
       end
     end

--- a/spec/unit/backend_spec.rb
+++ b/spec/unit/backend_spec.rb
@@ -2,6 +2,14 @@ require 'spec_helper'
 require 'hiera/util'
 
 class Hiera
+  module Backend
+    class Backend1x_backend
+      def lookup(key, scope, order_override, resolution_type)
+        ["a", "b"]
+      end
+    end
+  end
+
   describe Backend do
     describe "#datadir" do
       it "interpolates any values in the configured value" do
@@ -253,7 +261,7 @@ class Hiera
         scope = {}
         Config.load({:yaml => {:datadir => "/tmp"}})
         Config.load_backends
-        Backend::Yaml_backend.any_instance.stubs(:lookup).with("key1", scope, nil, :priority).returns("answer")
+        Backend::Yaml_backend.any_instance.stubs(:lookup).with("key1", scope, nil, :priority, instance_of(RecursiveGuard)).returns("answer")
 
         Backend.parse_string(input, scope).should == "answer"
       end
@@ -301,7 +309,7 @@ class Hiera
         scope = {}
         Config.load({:yaml => {:datadir => "/tmp"}})
         Config.load_backends
-        Backend::Yaml_backend.any_instance.stubs(:lookup).with("rspec", scope, nil, :priority).returns("test")
+        Backend::Yaml_backend.any_instance.stubs(:lookup).with("rspec", scope, nil, :priority, instance_of(RecursiveGuard)).returns("test")
         Backend.parse_answer(input, scope).should == "test_test_test"
       end
 
@@ -310,7 +318,7 @@ class Hiera
         scope = {}
         Config.load({:yaml => {:datadir => "/tmp"}})
         Config.load_backends
-        Backend::Yaml_backend.any_instance.stubs(:lookup).with("rspec", scope, nil, :priority).returns(['test', 'test'])
+        Backend::Yaml_backend.any_instance.stubs(:lookup).with("rspec", scope, nil, :priority, instance_of(RecursiveGuard)).returns(['test', 'test'])
         Backend.parse_answer(input, scope).should == ['test', 'test']
       end
 
@@ -319,7 +327,7 @@ class Hiera
         scope = {}
         Config.load({:yaml => {:datadir => "/tmp"}})
         Config.load_backends
-        Backend::Yaml_backend.any_instance.stubs(:lookup).with("rspec", scope, nil, :priority).returns(['test', 'test'])
+        Backend::Yaml_backend.any_instance.stubs(:lookup).with("rspec", scope, nil, :priority, instance_of(RecursiveGuard)).returns(['test', 'test'])
         expect do
           Backend.parse_answer(input, scope).should == ['test', 'test']
         end.to raise_error(Hiera::InterpolationInvalidValue, 'Cannot call alias in the string context')
@@ -330,7 +338,7 @@ class Hiera
         scope = {}
         Config.load({:yaml => {:datadir => "/tmp"}})
         Config.load_backends
-        Backend::Yaml_backend.any_instance.stubs(:lookup).with("rspec", scope, nil, :priority).returns(['test', 'test'])
+        Backend::Yaml_backend.any_instance.stubs(:lookup).with("rspec", scope, nil, :priority, instance_of(RecursiveGuard)).returns(['test', 'test'])
         expect do
           Backend.parse_answer(input, scope).should == ['test', 'test']
         end.to raise_error(Hiera::InterpolationInvalidValue, 'Cannot call alias in the string context')
@@ -341,7 +349,7 @@ class Hiera
         scope = {}
         Config.load({:yaml => {:datadir => "/tmp"}})
         Config.load_backends
-        Backend::Yaml_backend.any_instance.stubs(:lookup).with("rspec", scope, nil, :priority).returns("test")
+        Backend::Yaml_backend.any_instance.stubs(:lookup).with("rspec", scope, nil, :priority, instance_of(RecursiveGuard)).returns("test")
         Backend.parse_answer(input, scope).should == ["test_test_test", "test_test_test", ["test_test_test"]]
       end
 
@@ -350,7 +358,7 @@ class Hiera
         scope = {}
         Config.load({:yaml => {:datadir => "/tmp"}})
         Config.load_backends
-        Backend::Yaml_backend.any_instance.stubs(:lookup).with("rspec", scope, nil, :priority).returns("test")
+        Backend::Yaml_backend.any_instance.stubs(:lookup).with("rspec", scope, nil, :priority, instance_of(RecursiveGuard)).returns("test")
         Backend.parse_answer(input, scope).should == {"foo"=>"test_test_test", "bar"=>"test_test_test"}
       end
 
@@ -359,7 +367,7 @@ class Hiera
         scope = {}
         Config.load({:yaml => {:datadir => "/tmp"}})
         Config.load_backends
-        Backend::Yaml_backend.any_instance.stubs(:lookup).with("rspec", scope, nil, :priority).returns("foo")
+        Backend::Yaml_backend.any_instance.stubs(:lookup).with("rspec", scope, nil, :priority, instance_of(RecursiveGuard)).returns("foo")
         Backend.parse_answer(input, scope).should == {"foo"=>"test"}
       end
 
@@ -368,7 +376,7 @@ class Hiera
         scope = {}
         Config.load({:yaml => {:datadir => "/tmp"}})
         Config.load_backends
-        Backend::Yaml_backend.any_instance.stubs(:lookup).with("rspec", scope, nil, :priority).returns("foo")
+        Backend::Yaml_backend.any_instance.stubs(:lookup).with("rspec", scope, nil, :priority, instance_of(RecursiveGuard)).returns("foo")
         Backend.parse_answer(input, scope).should == {"topkey"=>{"foo" => "test"}}
       end
 
@@ -377,7 +385,7 @@ class Hiera
         scope = {}
         Config.load({:yaml => {:datadir => "/tmp"}})
         Config.load_backends
-        Backend::Yaml_backend.any_instance.stubs(:lookup).with("rspec", scope, nil, :priority).returns("test")
+        Backend::Yaml_backend.any_instance.stubs(:lookup).with("rspec", scope, nil, :priority, instance_of(RecursiveGuard)).returns("test")
         Backend.parse_answer(input, scope).should == {"foo"=>"test_test_test", "bar"=>["test_test_test", "test_test_test"]}
       end
 
@@ -386,7 +394,7 @@ class Hiera
         scope = {"rspec2" => "scope_rspec"}
         Config.load({:yaml => {:datadir => "/tmp"}})
         Config.load_backends
-        Backend::Yaml_backend.any_instance.stubs(:lookup).with("rspec", scope, nil, :priority).returns("hiera_rspec")
+        Backend::Yaml_backend.any_instance.stubs(:lookup).with("rspec", scope, nil, :priority, instance_of(RecursiveGuard)).returns("hiera_rspec")
         Backend.parse_answer(input, scope).should == {"foo"=>"test_hiera_rspec_test", "bar"=>"test_scope_rspec_test"}
       end
 
@@ -395,7 +403,7 @@ class Hiera
         scope = {"rspec" => "scope_rspec"}
         Config.load({:yaml => {:datadir => "/tmp"}})
         Config.load_backends
-        Backend::Yaml_backend.any_instance.stubs(:lookup).with("rspec", scope, nil, :priority).returns("hiera_rspec")
+        Backend::Yaml_backend.any_instance.stubs(:lookup).with("rspec", scope, nil, :priority, instance_of(RecursiveGuard)).returns("hiera_rspec")
         Backend.parse_answer(input, scope).should == "test_hiera_rspec_test_scope_rspec"
       end
 
@@ -457,7 +465,7 @@ class Hiera
         Config.load({:yaml => {:datadir => "/tmp"}})
         Config.load_backends
 
-        Backend::Yaml_backend.any_instance.expects(:lookup).with("key", {}, nil, nil).returns("answer")
+        Backend::Yaml_backend.any_instance.expects(:lookup).with("key", {}, nil, nil, nil).returns("answer")
 
         Backend.lookup("key", "default", {}, nil, nil).should == "answer"
       end
@@ -466,9 +474,9 @@ class Hiera
         Config.load({:yaml => {:datadir => "/tmp"}})
         Config.load_backends
 
-        Backend::Yaml_backend.any_instance.expects(:lookup).with("stringval", {}, nil, nil).returns("string")
-        Backend::Yaml_backend.any_instance.expects(:lookup).with("boolval", {}, nil, nil).returns(false)
-        Backend::Yaml_backend.any_instance.expects(:lookup).with("numericval", {}, nil, nil).returns(1)
+        Backend::Yaml_backend.any_instance.expects(:lookup).with("stringval", {}, nil, nil, nil).returns("string")
+        Backend::Yaml_backend.any_instance.expects(:lookup).with("boolval", {}, nil, nil, nil).returns(false)
+        Backend::Yaml_backend.any_instance.expects(:lookup).with("numericval", {}, nil, nil, nil).returns(1)
 
         Backend.lookup("stringval", "default", {}, nil, nil).should == "string"
         Backend.lookup("boolval", "default", {}, nil, nil).should == false
@@ -550,7 +558,7 @@ class Hiera
         Config.load_backends
 
         Backend.expects(:resolve_answer).with("test_test", :priority).returns("parsed")
-        Backend::Yaml_backend.any_instance.expects(:lookup).with("key", {"rspec" => "test"}, nil, :priority).returns("test_test")
+        Backend::Yaml_backend.any_instance.expects(:lookup).with("key", {"rspec" => "test"}, nil, :priority, nil).returns("test_test")
 
         Backend.lookup("key", "test_%{rspec}", {"rspec" => "test"}, nil, :priority).should == "parsed"
       end
@@ -559,7 +567,7 @@ class Hiera
         Config.load({:yaml => {:datadir => "/tmp"}})
         Config.load_backends
 
-        Backend::Yaml_backend.any_instance.expects(:lookup).with("key", {"rspec" => "test"}, nil, nil)
+        Backend::Yaml_backend.any_instance.expects(:lookup).with("key", {"rspec" => "test"}, nil, nil, nil)
 
         Backend.lookup("key", "test_%{rspec}", {"rspec" => "test"}, nil, nil).should == "test_test"
       end
@@ -567,42 +575,42 @@ class Hiera
       it "keeps string default data as a string" do
         Config.load({:yaml => {:datadir => "/tmp"}})
         Config.load_backends
-        Backend::Yaml_backend.any_instance.expects(:lookup).with("key", {}, nil, nil)
+        Backend::Yaml_backend.any_instance.expects(:lookup).with("key", {}, nil, nil, nil)
         Backend.lookup("key", "test", {}, nil, nil).should == "test"
       end
 
       it "keeps array default data as an array" do
         Config.load({:yaml => {:datadir => "/tmp"}})
         Config.load_backends
-        Backend::Yaml_backend.any_instance.expects(:lookup).with("key", {}, nil, :array)
+        Backend::Yaml_backend.any_instance.expects(:lookup).with("key", {}, nil, :array, nil)
         Backend.lookup("key", ["test"], {}, nil, :array).should == ["test"]
       end
 
       it "keeps hash default data as a hash" do
         Config.load({:yaml => {:datadir => "/tmp"}})
         Config.load_backends
-        Backend::Yaml_backend.any_instance.expects(:lookup).with("key", {}, nil, :hash)
+        Backend::Yaml_backend.any_instance.expects(:lookup).with("key", {}, nil, :hash, nil)
         Backend.lookup("key", {"test" => "value"}, {}, nil, :hash).should == {"test" => "value"}
       end
 
       it 'can use qualified key to lookup value in hash' do
         Config.load({:yaml => {:datadir => '/tmp'}})
         Config.load_backends
-        Backend::Yaml_backend.any_instance.expects(:lookup).with('key', {}, nil, nil).returns({ 'test' => 'value'})
+        Backend::Yaml_backend.any_instance.expects(:lookup).with('key', {}, nil, nil, nil).returns({ 'test' => 'value'})
         Backend.lookup('key.test', 'dflt', {}, nil, nil).should == 'value'
       end
 
       it 'can use qualified key to lookup value in array' do
         Config.load({:yaml => {:datadir => '/tmp'}})
         Config.load_backends
-        Backend::Yaml_backend.any_instance.expects(:lookup).with('key', {}, nil, nil).returns([ 'first', 'second'])
+        Backend::Yaml_backend.any_instance.expects(:lookup).with('key', {}, nil, nil, nil).returns([ 'first', 'second'])
         Backend.lookup('key.1', 'dflt', {}, nil, nil).should == 'second'
       end
 
       it 'will fail when qualified key is partially found but not expected hash' do
         Config.load({:yaml => {:datadir => '/tmp'}})
         Config.load_backends
-        Backend::Yaml_backend.any_instance.expects(:lookup).with('key', {}, nil, nil).returns(['value 1', 'value 2'])
+        Backend::Yaml_backend.any_instance.expects(:lookup).with('key', {}, nil, nil, nil).returns(['value 1', 'value 2'])
         expect do
           Backend.lookup('key.test', 'dflt', {}, nil, nil)
         end.to raise_error(Exception, /^Hiera type mismatch:/)
@@ -623,14 +631,14 @@ class Hiera
       it 'will succeed when qualified key used with resolution_type :priority' do
         Config.load({:yaml => {:datadir => '/tmp'}})
         Config.load_backends
-        Backend::Yaml_backend.any_instance.expects(:lookup).with('key', {}, nil, :priority).returns({ 'test' => 'value'})
+        Backend::Yaml_backend.any_instance.expects(:lookup).with('key', {}, nil, :priority, nil).returns({ 'test' => 'value'})
         Backend.lookup('key.test', 'dflt', {}, nil, :priority).should == 'value'
       end
 
       it 'will fail when qualified key is partially found but not expected array' do
         Config.load({:yaml => {:datadir => '/tmp'}})
         Config.load_backends
-        Backend::Yaml_backend.any_instance.expects(:lookup).with('key', {}, nil, nil).returns({ 'test' => 'value'})
+        Backend::Yaml_backend.any_instance.expects(:lookup).with('key', {}, nil, nil, nil).returns({ 'test' => 'value'})
         expect do
           Backend.lookup('key.2', 'dflt', {}, nil, nil)
         end.to raise_error(Exception, /^Hiera type mismatch:/)
@@ -639,14 +647,14 @@ class Hiera
       it 'will not fail when qualified key is partially not found' do
         Config.load({:yaml => {:datadir => '/tmp'}})
         Config.load_backends
-        Backend::Yaml_backend.any_instance.expects(:lookup).with('key', {}, nil, nil).returns(nil)
+        Backend::Yaml_backend.any_instance.expects(:lookup).with('key', {}, nil, nil, nil).returns(nil)
         Backend.lookup('key.test', 'dflt', {}, nil, nil).should == 'dflt'
       end
 
       it 'will not fail when qualified key is array index out of bounds' do
         Config.load({:yaml => {:datadir => '/tmp'}})
         Config.load_backends
-        Backend::Yaml_backend.any_instance.expects(:lookup).with('key', {}, nil, nil).returns(['value 1', 'value 2'])
+        Backend::Yaml_backend.any_instance.expects(:lookup).with('key', {}, nil, nil, nil).returns(['value 1', 'value 2'])
         Backend.lookup('key.33', 'dflt', {}, nil, nil).should == 'dflt'
       end
 
@@ -662,8 +670,16 @@ class Hiera
         Config.load({:yaml => {:datadir => '/tmp'}})
         Config.load_backends
         scope = { 'some' => { 'test' => 'value'}}
-        Backend::Yaml_backend.any_instance.expects(:lookup).with('key', scope, nil, nil)
+        Backend::Yaml_backend.any_instance.expects(:lookup).with('key', scope, nil, nil, nil)
         Backend.lookup('key.notfound', '%{some.test}', scope, nil, nil).should == 'value'
+      end
+
+      it "handles older backend with 4 argument lookup" do
+        Config.load({})
+        Config.instance_variable_set("@config", {:backends => ["Backend1x"]})
+
+        Hiera.expects(:debug).at_least_once.with(regexp_matches /Using Hiera 1.x backend/)
+        Backend.lookup("key", {}, {"rspec" => "test"}, nil, :priority).should == ["a", "b"]
       end
     end
 

--- a/spec/unit/fixtures/interpolate/config/hiera.yaml
+++ b/spec/unit/fixtures/interpolate/config/hiera.yaml
@@ -1,0 +1,5 @@
+:backends:
+  - yaml
+
+:hierarchy:
+  - recursive

--- a/spec/unit/fixtures/interpolate/data/recursive.yaml
+++ b/spec/unit/fixtures/interpolate/data/recursive.yaml
@@ -1,0 +1,3 @@
+foo: '%{hiera("bar")}'
+
+bar: '%{hiera("foo")}'

--- a/spec/unit/interpolate_spec.rb
+++ b/spec/unit/interpolate_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+require 'hiera/util'
+
+describe "Hiera" do
+  context "when doing interpolation" do
+    let(:fixtures) { File.join(HieraSpec::FIXTURE_DIR, 'interpolate') }
+
+    it 'should prevent endless recursion' do
+      Hiera::Util.expects(:var_dir).at_least_once.returns(File.join(fixtures, 'data'))
+      hiera =  Hiera.new(:config => File.join(fixtures, 'config', 'hiera.yaml'))
+      expect do
+        hiera.lookup('foo', nil, {})
+      end.to raise_error Hiera::InterpolationLoop, 'Detected in [hiera("bar"), hiera("foo")]'
+    end
+  end
+end


### PR DESCRIPTION
This commit ensures that only one RecursiveGuard instance is
used in a lookup even if that lookup results in multiple
interpolations.

A backend implementation must add and pass on a fifth
'recurse_guard' argument but the implementation will accept
the old API with four arguments as well for backward
compatibility.