### PR TITLE
(HI-14) Implement structure traversal lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,13 +85,20 @@ array.  This is used in the hiera-puppet project to replace External Node Classi
 creating a Hiera compatible include function.
 
 ### Qualified Key Lookup
-You can use a qualified key to lookup a value that is contained inside a hash:
+You can use a qualified key to lookup a value that is contained inside a hash or array:
 
 <pre>
 $ hiera user
-{"name"=>"hiera", "home"=>"/home/hiera"}
+{"name"=>"kim", "home"=>"/home/kim"}
 $ hiera user.name
-hiera
+kim
+</pre>
+
+<pre>
+$ hiera ssh_users
+["root", "jeff", "gary", "hunter"]
+$ hiera ssh_users.0
+root
 </pre>
 
 ## Future Enhancements

--- a/README.md
+++ b/README.md
@@ -84,6 +84,16 @@ Hiera can search through all the tiers in a hierarchy and merge the result into 
 array.  This is used in the hiera-puppet project to replace External Node Classifiers by
 creating a Hiera compatible include function.
 
+### Qualified Key Lookup
+You can use a qualified key to lookup a value that is contained inside a hash:
+
+<pre>
+$ hiera user
+{"name"=>"hiera", "home"=>"/home/hiera"}
+$ hiera user.name
+hiera
+</pre>
+
 ## Future Enhancements
 
  * More backends should be created

--- a/lib/hiera/interpolate.rb
+++ b/lib/hiera/interpolate.rb
@@ -71,11 +71,9 @@ class Hiera::Interpolate
     private :get_interpolation_method_and_key
 
     def scope_interpolate(data, key, scope, extra_data)
-      value = scope[key]
-      if value.nil? || value == :undefined
-        value = extra_data[key]
-      end
-
+      segments = key.split('.')
+      value = Hiera::Backend.qualified_lookup(segments, scope)
+      value = Hiera::Backend.qualified_lookup(segments, extra_data) if value.nil? || value == :undefined
       value
     end
     private :scope_interpolate

--- a/lib/hiera/interpolate.rb
+++ b/lib/hiera/interpolate.rb
@@ -73,8 +73,7 @@ class Hiera::Interpolate
     def scope_interpolate(data, key, scope, extra_data)
       segments = key.split('.')
       value = Hiera::Backend.qualified_lookup(segments, scope)
-      value = Hiera::Backend.qualified_lookup(segments, extra_data) if value.nil? || value == :undefined
-      value
+      value.nil? ? Hiera::Backend.qualified_lookup(segments, extra_data) : value
     end
     private :scope_interpolate
 

--- a/spec/unit/backend_spec.rb
+++ b/spec/unit/backend_spec.rb
@@ -181,17 +181,6 @@ class Hiera
         "test_%{scope('rspec')}_test" => "test__test"
       }
 
-      @interprets_undefined_in_scope_tests.each do |input, expected|
-        it "interprets :undefined in scope as a non-value" do
-          Backend.parse_string(input, {"rspec" => :undefined}).should == expected
-        end
-      end
-
-      it "uses the value from extra_data when scope is :undefined" do
-        input = "test_%{rspec}_test"
-        Backend.parse_string(input, {"rspec" => :undefined}, { "rspec" => "extra" }).should == "test_extra_test"
-      end
-
       @exact_lookup_tests = {
         "test_%{::rspec::data}_test" => "test_value_test",
         "test_%{scope('::rspec::data')}_test" => "test_value_test"
@@ -617,6 +606,25 @@ class Hiera
         expect do
           Backend.lookup('key.test', 'dflt', {}, nil, nil)
         end.to raise_error(Exception, /^Hiera type mismatch:/)
+      end
+
+      it 'will fail when qualified key used with resolution_type :hash' do
+        expect do
+          Backend.lookup('key.test', 'dflt', {}, nil, :hash)
+        end.to raise_error(ArgumentError, /^Resolution type :hash is illegal/)
+      end
+
+      it 'will fail when qualified key used with resolution_type :array' do
+        expect do
+          Backend.lookup('key.test', 'dflt', {}, nil, :array)
+        end.to raise_error(ArgumentError, /^Resolution type :array is illegal/)
+      end
+
+      it 'will succeed when qualified key used with resolution_type :priority' do
+        Config.load({:yaml => {:datadir => '/tmp'}})
+        Config.load_backends
+        Backend::Yaml_backend.any_instance.expects(:lookup).with('key', {}, nil, :priority).returns({ 'test' => 'value'})
+        Backend.lookup('key.test', 'dflt', {}, nil, :priority).should == 'value'
       end
 
       it 'will fail when qualified key is partially found but not expected array' do


### PR DESCRIPTION
Previously hiera would not recognize qualified names containing
dots. This commit changes the lookup so that a key containing
dots can be used for doing qualified lookups in values that are
known to be hashes. For example:

    $ hiera user
    {"name"=>"kim", "home"=>"/home/kim"}

    $ hiera user.name
    kim

    $ hiera ssh_users
    ["root", "jeff", "gary", "hunter"]

    $ hiera ssh_users.0
    root