### PR TITLE
(HI-298) Change config-dir and var-dir settings

### DIFF
--- a/ext/hiera.yaml
+++ b/ext/hiera.yaml
@@ -9,7 +9,7 @@
 
 :yaml:
 # datadir is empty here, so hiera uses its defaults:
-# - /var/lib/hiera on *nix
+# - /etc/puppetlabs/agent/code/hieradata on *nix
 # - %CommonAppData%\PuppetLabs\hiera\var on Windows
 # When specifying a datadir, make sure the directory exists.
   :datadir:

--- a/lib/hiera/util.rb
+++ b/lib/hiera/util.rb
@@ -23,7 +23,7 @@ class Hiera
       if microsoft_windows?
          File.join(common_appdata, 'PuppetLabs', 'hiera', 'etc')
       else
-        '/etc'
+        '/etc/puppetlabs/agent/code'
       end
     end
 
@@ -31,7 +31,7 @@ class Hiera
       if microsoft_windows?
         File.join(common_appdata, 'PuppetLabs', 'hiera', 'var')
       else
-        '/var/lib/hiera'
+        '/etc/puppetlabs/agent/code/hieradata'
       end
     end
 

--- a/spec/unit/util_spec.rb
+++ b/spec/unit/util_spec.rb
@@ -23,7 +23,7 @@ describe Hiera::Util do
   describe 'Hiera::Util.config_dir' do
     it 'should return the correct path for posix systems' do
       Hiera::Util.expects(:file_alt_separator).returns(nil)
-      Hiera::Util.config_dir.should == '/etc'
+      Hiera::Util.config_dir.should == '/etc/puppetlabs/agent/code'
     end
 
     it 'should return the correct path for microsoft windows systems' do
@@ -36,7 +36,7 @@ describe Hiera::Util do
   describe 'Hiera::Util.var_dir' do
     it 'should return the correct path for posix systems' do
       Hiera::Util.expects(:file_alt_separator).returns(nil)
-      Hiera::Util.var_dir.should == '/var/lib/hiera'
+      Hiera::Util.var_dir.should == '/etc/puppetlabs/agent/code/hieradata'
     end
 
     it 'should return the correct path for microsoft windows systems' do


### PR DESCRIPTION
Changes the config_dir to '/etc/puppetlabs/agent/code' and the
var_dir to '/etc/puppetlabs/agent/code/hieradata' for posix style
systems. The corresponding paths for windows are unchanged.

The changes have been tested by running the spec tests in
current puppet/master branch while using this hiera source.