### PR TITLE
(HI-298) Update hiera.yaml path in acceptance tests

### DIFF
--- a/acceptance/tests/yaml_backend/00-setup.rb
+++ b/acceptance/tests/yaml_backend/00-setup.rb
@@ -2,7 +2,16 @@ test_name "Hiera setup for YAML backend"
 
 agents.each do |agent|
   apply_manifest_on agent, <<-PP
-file { '/etc/hiera.yaml':
+file { '/etc/puppetlabs':
+  ensure  => directory,
+}->
+file { '/etc/puppetlabs/agent':
+  ensure  => directory,
+}->
+file { '/etc/puppetlabs/agent/code':
+  ensure  => directory,
+}->
+file { '/etc/puppetlabs/agent/code/hiera.yaml':
   ensure  => present,
   content => '---
     :backends:


### PR DESCRIPTION
This commit updates the path to the hiera.yaml file in accordance with the
pathing changes in commit 602c682. This path cannot yet be parameterized and
is hard coded to `/etc/puppetlabs/agent/code/hiera.yaml` in the 00-setup.rb
test.