### PR TITLE
(HI-282) Fix inventory service lookups in Puppet 3

### DIFF
--- a/bin/hiera
+++ b/bin/hiera
@@ -105,7 +105,8 @@ def load_scope(source, type=:yaml)
       if Puppet::Util::Package.versioncmp(puppet_version, '3.0.0') < 0
         Puppet.settings.parse
       else
-        Puppet.instance_eval { do_initialize_settings_for_run_mode(:master, []) }
+        raise "Puppet 4 does not support the inventory service" unless Puppet.respond_to?(:initialize_settings_for_run_mode)
+        Puppet.initialize_settings_for_run_mode(:master)
       end
 
       Puppet::Node::Facts.indirection.terminus_class = :rest

--- a/bin/hiera
+++ b/bin/hiera
@@ -101,11 +101,14 @@ def load_scope(source, type=:yaml)
     begin
       require 'puppet'
 
+      unless Puppet::Indirector::Terminus.terminus_classes(:facts).include?(:rest)
+        raise "rest facts terminus not present; Puppet 4+ does not support the inventory service"
+      end
+
       puppet_version = Puppet.version.split(' ').first # handle PE
       if Puppet::Util::Package.versioncmp(puppet_version, '3.0.0') < 0
         Puppet.settings.parse
       else
-        raise "Puppet 4 does not support the inventory service" unless Puppet.respond_to?(:initialize_settings_for_run_mode)
         Puppet.initialize_settings_for_run_mode(:master)
       end
 

--- a/bin/hiera
+++ b/bin/hiera
@@ -99,10 +99,21 @@ def load_scope(source, type=:yaml)
     # is fine to have the inventory_server option set even if the config
     # doesn't have the fact_terminus set to rest.
     begin
-      require 'puppet/util/run_mode'
-      $puppet_application_mode = Puppet::Util::RunMode[:master]
       require 'puppet'
-      Puppet.settings.parse
+
+      puppet_version = Puppet.version.split(' ').first # handle PE
+      if Puppet::Util::Package.versioncmp(puppet_version, '3.0.0') < 0
+        Puppet.settings.parse
+      else
+        Puppet.settings.initialize_global_settings
+        puppet_app_defaults = Puppet::Settings.app_defaults_for_run_mode(Puppet::Util::RunMode[:master])
+        Puppet.settings.initialize_app_defaults(puppet_app_defaults)
+
+        if Puppet::Util::Package.versioncmp(puppet_version, '3.5.0') >= 0
+          Puppet.push_context(Puppet.base_context(Puppet.settings), "Initial context after settings initialization")
+        end
+      end
+
       Puppet::Node::Facts.indirection.terminus_class = :rest
       scope = YAML.load(Puppet::Node::Facts.indirection.find(source).to_yaml)
       # Puppet makes dumb yaml files that do not promote data reuse.

--- a/bin/hiera
+++ b/bin/hiera
@@ -105,13 +105,7 @@ def load_scope(source, type=:yaml)
       if Puppet::Util::Package.versioncmp(puppet_version, '3.0.0') < 0
         Puppet.settings.parse
       else
-        Puppet.settings.initialize_global_settings
-        puppet_app_defaults = Puppet::Settings.app_defaults_for_run_mode(Puppet::Util::RunMode[:master])
-        Puppet.settings.initialize_app_defaults(puppet_app_defaults)
-
-        if Puppet::Util::Package.versioncmp(puppet_version, '3.5.0') >= 0
-          Puppet.push_context(Puppet.base_context(Puppet.settings), "Initial context after settings initialization")
-        end
+        Puppet.instance_eval { do_initialize_settings_for_run_mode(:master, []) }
       end
 
       Puppet::Node::Facts.indirection.terminus_class = :rest


### PR DESCRIPTION
Puppet 3 changed the API for parsing the settings files. Puppet 3.5 changed it further. This brings those changes into Hiera for systems using Puppet 3.