### PR TITLE
(HI-298) Strip 'agent/' part of default paths.

### DIFF
--- a/acceptance/tests/yaml_backend/00-setup.rb
+++ b/acceptance/tests/yaml_backend/00-setup.rb
@@ -5,13 +5,10 @@ agents.each do |agent|
 file { '/etc/puppetlabs':
   ensure  => directory,
 }->
-file { '/etc/puppetlabs/agent':
+file { '/etc/puppetlabs/code':
   ensure  => directory,
 }->
-file { '/etc/puppetlabs/agent/code':
-  ensure  => directory,
-}->
-file { '/etc/puppetlabs/agent/code/hiera.yaml':
+file { '/etc/puppetlabs/code/hiera.yaml':
   ensure  => present,
   content => '---
     :backends:

--- a/ext/hiera.yaml
+++ b/ext/hiera.yaml
@@ -9,7 +9,7 @@
 
 :yaml:
 # datadir is empty here, so hiera uses its defaults:
-# - /etc/puppetlabs/agent/code/hieradata on *nix
+# - /etc/puppetlabs/code/hieradata on *nix
 # - %CommonAppData%\PuppetLabs\hiera\var on Windows
 # When specifying a datadir, make sure the directory exists.
   :datadir:

--- a/lib/hiera/util.rb
+++ b/lib/hiera/util.rb
@@ -23,7 +23,7 @@ class Hiera
       if microsoft_windows?
          File.join(common_appdata, 'PuppetLabs', 'hiera', 'etc')
       else
-        '/etc/puppetlabs/agent/code'
+        '/etc/puppetlabs/code'
       end
     end
 
@@ -31,7 +31,7 @@ class Hiera
       if microsoft_windows?
         File.join(common_appdata, 'PuppetLabs', 'hiera', 'var')
       else
-        '/etc/puppetlabs/agent/code/hieradata'
+        '/etc/puppetlabs/code/hieradata'
       end
     end
 

--- a/spec/unit/util_spec.rb
+++ b/spec/unit/util_spec.rb
@@ -23,7 +23,7 @@ describe Hiera::Util do
   describe 'Hiera::Util.config_dir' do
     it 'should return the correct path for posix systems' do
       Hiera::Util.expects(:file_alt_separator).returns(nil)
-      Hiera::Util.config_dir.should == '/etc/puppetlabs/agent/code'
+      Hiera::Util.config_dir.should == '/etc/puppetlabs/code'
     end
 
     it 'should return the correct path for microsoft windows systems' do
@@ -36,7 +36,7 @@ describe Hiera::Util do
   describe 'Hiera::Util.var_dir' do
     it 'should return the correct path for posix systems' do
       Hiera::Util.expects(:file_alt_separator).returns(nil)
-      Hiera::Util.var_dir.should == '/etc/puppetlabs/agent/code/hieradata'
+      Hiera::Util.var_dir.should == '/etc/puppetlabs/code/hieradata'
     end
 
     it 'should return the correct path for microsoft windows systems' do


### PR DESCRIPTION
This commit removes the 'agent' segment from the config_dir and
var_dir properties of the Util class. It also updates the sample
and tests (unit and acceptance) to reflect the change.