### PR TITLE
(HI-337) Distinguish between nil values and missing keys

### DIFF
--- a/lib/hiera/backend.rb
+++ b/lib/hiera/backend.rb
@@ -233,14 +233,20 @@ class Hiera
           subsegments = segments.drop(1)
         end
 
+        found = false
         Config[:backends].each do |backend|
           backend_constant = "#{backend.capitalize}_backend"
           if constants.include?(backend_constant) || constants.include?(backend_constant.to_sym)
             backend = (@backends[backend] ||= find_backend(backend_constant))
-            new_answer = backend.lookup(segments[0], scope, order_override, resolution_type, context)
-            new_answer = qualified_lookup(subsegments, new_answer) unless subsegments.nil?
-
-            next if new_answer.nil?
+            found_in_backend = false
+            new_answer = catch(:no_such_key) do
+              value = backend.lookup(segments[0], scope, order_override, resolution_type, context)
+              value = qualified_lookup(subsegments, value) unless subsegments.nil?
+              found_in_backend = true
+              value
+            end
+            next unless found_in_backend
+            found = true
 
             case resolution_type
             when :array
@@ -259,9 +265,9 @@ class Hiera
         end
 
         answer = resolve_answer(answer, resolution_type) unless answer.nil?
-        answer = parse_string(default, scope, {}, context) if answer.nil? and default.is_a?(String)
+        answer = parse_string(default, scope, {}, context) if !found && default.is_a?(String)
 
-        return default if answer.nil?
+        return default if !found && answer.nil?
         return answer
       end
 
@@ -272,12 +278,14 @@ class Hiera
       def qualified_lookup(segments, hash)
         value = hash
         segments.each do |segment|
-          break if value.nil?
+          throw :no_such_key if value.nil?
           if segment =~ /^[0-9]+$/
             segment = segment.to_i
             raise Exception, "Hiera type mismatch: Got #{value.class.name} when Array was expected enable lookup using key '#{segment}'" unless value.instance_of?(Array)
+            throw :no_such_key unless segment < value.size
           else
             raise Exception, "Hiera type mismatch: Got #{value.class.name} when a non Array object that responds to '[]' was expected to enable lookup using key '#{segment}'" unless value.respond_to?(:'[]') && !value.instance_of?(Array);
+            throw :no_such_key unless value.include?(segment)
           end
           value = value[segment]
         end

--- a/lib/hiera/backend.rb
+++ b/lib/hiera/backend.rb
@@ -15,7 +15,12 @@ class Hiera
 
       def lookup(key, scope, order_override, resolution_type, context)
         Hiera.debug("Using Hiera 1.x backend API to access instance of class #{@wrapped.class.name}. Lookup recursion will not be detected")
-        @wrapped.lookup(key, scope, order_override, resolution_type)
+        value = @wrapped.lookup(key, scope, order_override, resolution_type)
+
+        # The most likely cause when an old backend returns nil is that the key was not found. In any case, it is
+        # impossible to know the difference between that and a found nil. The throw here preserves the old behavior.
+        throw (:no_such_key) if value.nil?
+        value
       end
     end
 

--- a/lib/hiera/backend/json_backend.rb
+++ b/lib/hiera/backend/json_backend.rb
@@ -11,6 +11,7 @@ class Hiera
 
       def lookup(key, scope, order_override, resolution_type, context)
         answer = nil
+        found = false
 
         Hiera.debug("Looking up #{key} in JSON backend")
 
@@ -27,6 +28,7 @@ class Hiera
 
           next if data.empty?
           next unless data.include?(key)
+          found = true
 
           # for array resolution we just append to the array whatever
           # we find, we then goes onto the next file and keep adding to
@@ -48,7 +50,7 @@ class Hiera
             break
           end
         end
-
+        throw :no_such_key unless found
         return answer
       end
     end

--- a/lib/hiera/backend/yaml_backend.rb
+++ b/lib/hiera/backend/yaml_backend.rb
@@ -10,6 +10,7 @@ class Hiera
 
       def lookup(key, scope, order_override, resolution_type, context)
         answer = nil
+        found = false
 
         Hiera.debug("Looking up #{key} in YAML backend")
 
@@ -20,6 +21,7 @@ class Hiera
 
           next if data.empty?
           next unless data.include?(key)
+          found = true
 
           # Extra logging that we found the key. This can be outputted
           # multiple times if the resolution type is array or hash but that
@@ -47,7 +49,7 @@ class Hiera
             break
           end
         end
-
+        throw :no_such_key unless found
         return answer
       end
 

--- a/lib/hiera/interpolate.rb
+++ b/lib/hiera/interpolate.rb
@@ -75,8 +75,8 @@ class Hiera::Interpolate
 
     def scope_interpolate(data, key, scope, extra_data, context)
       segments = key.split('.')
-      value = Hiera::Backend.qualified_lookup(segments, scope)
-      value.nil? ? Hiera::Backend.qualified_lookup(segments, extra_data) : value
+      catch(:no_such_key) { return Hiera::Backend.qualified_lookup(segments, scope) }
+      catch(:no_such_key) { Hiera::Backend.qualified_lookup(segments, extra_data) }
     end
     private :scope_interpolate
 

--- a/spec/unit/backend/json_backend_spec.rb
+++ b/spec/unit/backend/json_backend_spec.rb
@@ -25,7 +25,7 @@ class Hiera
           Backend.expects(:datafile).with(:json, {}, "one", "json").returns(nil)
           Backend.expects(:datafile).with(:json, {}, "two", "json").returns(nil)
 
-          @backend.lookup("key", {}, nil, :priority, nil)
+          expect { @backend.lookup("key", {}, nil, :priority, nil) }.to throw_symbol(:no_such_key)
         end
 
         it "should retain the data types found in data files" do

--- a/spec/unit/backend/yaml_backend_spec.rb
+++ b/spec/unit/backend/yaml_backend_spec.rb
@@ -49,14 +49,19 @@ class Hiera
             Backend.expects(:datasourcefiles).with(:yaml, {}, "yaml", nil).yields(["one", "/nonexisting/one.yaml"])
           end
 
-          it "returns nil when the YAML value is nil" do
+          it "throws :no_such_key when key is missing in YAML" do
             @cache.value = "---\n"
+            expect { @backend.lookup("key", {}, nil, :priority, nil) }.to throw_symbol(:no_such_key)
+          end
+
+          it "returns nil when the YAML value is nil" do
+            @cache.value = "key: ~\n"
             @backend.lookup("key", {}, nil, :priority, nil).should be_nil
           end
 
-          it "returns nil when the YAML file is false" do
+          it "throws :no_such_key when the YAML file is false" do
             @cache.value = ""
-            @backend.lookup("key", {}, nil, :priority, nil).should be_nil
+            expect { @backend.lookup("key", {}, nil, :priority, nil) }.to throw_symbol(:no_such_key)
           end
 
           it "raises a TypeError when the YAML value is not a hash" do

--- a/spec/unit/backend_spec.rb
+++ b/spec/unit/backend_spec.rb
@@ -572,29 +572,38 @@ class Hiera
         Config.load({:yaml => {:datadir => "/tmp"}})
         Config.load_backends
 
-        Backend::Yaml_backend.any_instance.expects(:lookup).with("key", {"rspec" => "test"}, nil, nil, instance_of(Hash))
+        Backend::Yaml_backend.any_instance.expects(:lookup).with("key", {"rspec" => "test"}, nil, nil, instance_of(Hash)).throws(:no_such_key)
 
         Backend.lookup("key", "test_%{rspec}", {"rspec" => "test"}, nil, nil).should == "test_test"
+      end
+
+      it "returns nil instead of the default when key is found with a nil value" do
+        Config.load({:yaml => {:datadir => "/tmp"}})
+        Config.load_backends
+
+        Backend::Yaml_backend.any_instance.expects(:lookup).with("key", {"rspec" => "test"}, nil, nil, instance_of(Hash)).returns(nil)
+
+        Backend.lookup("key", "test_%{rspec}", {"rspec" => "test"}, nil, nil).should == nil
       end
 
       it "keeps string default data as a string" do
         Config.load({:yaml => {:datadir => "/tmp"}})
         Config.load_backends
-        Backend::Yaml_backend.any_instance.expects(:lookup).with("key", {}, nil, nil, instance_of(Hash))
+        Backend::Yaml_backend.any_instance.expects(:lookup).with("key", {}, nil, nil, instance_of(Hash)).throws(:no_such_key)
         Backend.lookup("key", "test", {}, nil, nil).should == "test"
       end
 
       it "keeps array default data as an array" do
         Config.load({:yaml => {:datadir => "/tmp"}})
         Config.load_backends
-        Backend::Yaml_backend.any_instance.expects(:lookup).with("key", {}, nil, :array, instance_of(Hash))
+        Backend::Yaml_backend.any_instance.expects(:lookup).with("key", {}, nil, :array, instance_of(Hash)).throws(:no_such_key)
         Backend.lookup("key", ["test"], {}, nil, :array).should == ["test"]
       end
 
       it "keeps hash default data as a hash" do
         Config.load({:yaml => {:datadir => "/tmp"}})
         Config.load_backends
-        Backend::Yaml_backend.any_instance.expects(:lookup).with("key", {}, nil, :hash, instance_of(Hash))
+        Backend::Yaml_backend.any_instance.expects(:lookup).with("key", {}, nil, :hash, instance_of(Hash)).throws(:no_such_key)
         Backend.lookup("key", {"test" => "value"}, {}, nil, :hash).should == {"test" => "value"}
       end
 

--- a/spec/unit/fixtures/interpolate/config/hiera.yaml
+++ b/spec/unit/fixtures/interpolate/config/hiera.yaml
@@ -3,3 +3,4 @@
 
 :hierarchy:
   - recursive
+  - niltest

--- a/spec/unit/fixtures/interpolate/data/niltest.yaml
+++ b/spec/unit/fixtures/interpolate/data/niltest.yaml
@@ -1,0 +1,2 @@
+niltest: 'Missing key #%{hiera("knotfound")}#. Key with nil #%{hiera("knil")}#'
+knil: null

--- a/spec/unit/interpolate_spec.rb
+++ b/spec/unit/interpolate_spec.rb
@@ -14,6 +14,16 @@ describe "Hiera" do
     end
   end
 
+  context "when not finding value for interpolated key" do
+    let(:fixtures) { File.join(HieraSpec::FIXTURE_DIR, 'interpolate') }
+
+    it 'should resolve the interpolation to an empty string' do
+      Hiera::Util.expects(:var_dir).at_least_once.returns(File.join(fixtures, 'data'))
+      hiera = Hiera.new(:config => File.join(fixtures, 'config', 'hiera.yaml'))
+      expect(hiera.lookup('niltest', nil, {})).to eq('Missing key ##. Key with nil ##')
+    end
+  end
+
   context "when doing interpolation with override" do
     let(:fixtures) { File.join(HieraSpec::FIXTURE_DIR, 'override') }
 


### PR DESCRIPTION
This commit changes the JSON and YAML backends so that they throws
a :no_such_key exception when the key is missing and returns nil for
a key that is found but has a nil value. The Backend that calls those
backends will recognize this distinction and only use the 'extras'
hash and 'default' value when the key is missing. In contrast, a nil
return will be treated as a valid value and returned to the caller.

In addition to the hiera spec tests, this test has also been spec tested from puppet master.