### PR TITLE
(#HI-338) Don't merge: This adds explain functionality

### DIFF
--- a/bin/hiera
+++ b/bin/hiera
@@ -148,6 +148,10 @@ OptionParser.new do |opts|
     options[:verbose] = true
   end
 
+  opts.on("--explain", "-e", "Describe how Hiera will be looking up data given current scope and configuration") do
+    options[:explain] = true
+  end
+
   opts.on("--array", "-a", "Return all values as an array") do
     options[:resolution_type] = :array
   end
@@ -210,7 +214,10 @@ end
 #
 # The var=val's assign scope
 unless ARGV.empty?
-  options[:key] = ARGV.delete_at(0)
+  # if this is a bareword, ie not a FACT=value argument. Allows explain without a lookup
+  unless ARGV.first =~ /^(.+?)=(.+?)$/
+    options[:key] = ARGV.delete_at(0)
+  end
 
   ARGV.each do |arg|
     if arg =~ /^(.+?)=(.+?)$/
@@ -223,9 +230,10 @@ unless ARGV.empty?
       end
     end
   end
-else
-  STDERR.puts "Please supply a data item to look up"
-  exit 1
+end
+
+unless options[:verbose]
+  Hiera.logger = "noop"
 end
 
 begin
@@ -239,10 +247,17 @@ rescue Exception => e
   end
 end
 
-unless options[:verbose]
-  Hiera.logger = "noop"
+if options[:explain]
+  hiera.explain(options[:scope])
 end
 
-ans = hiera.lookup(options[:key], options[:default], options[:scope], nil, options[:resolution_type])
-
-output_answer(ans, options[:format])
+# This conditional allow explain to run with or without a key lookup
+if options[:key]
+  ans = hiera.lookup(options[:key], options[:default], options[:scope], nil, options[:resolution_type])
+  output_answer(ans, options[:format])
+else
+  unless options[:explain]
+    STDERR.puts "Please supply a data item to look up"
+    exit 1
+  end
+end

--- a/lib/hiera.rb
+++ b/lib/hiera.rb
@@ -59,5 +59,12 @@ class Hiera
   def lookup(key, default, scope, order_override=nil, resolution_type=:priority)
     Backend.lookup(key, default, scope, order_override, resolution_type)
   end
+
+  # Just describe where Hiera would be retrieving data, given the current
+  # scope and configuration.
+  #
+  def explain(scope)
+    puts Backend.explain(scope)
+  end
 end
 

--- a/lib/hiera/backend.rb
+++ b/lib/hiera/backend.rb
@@ -265,6 +265,33 @@ class Hiera
         return answer
       end
 
+      # Return a string describing where Hiera would be retrieving data, given
+      # the current scope and configuration.
+      def explain(scope)
+        str = "Backend data directories:\n"
+        Config[:backends].each do |backend|
+          str << "  * #{backend}: #{Backend.datadir(backend, scope)}\n"
+        end
+
+        str << "\nExpanded hierarchy:\n"
+        Backend.datasources(scope) do |datasource|
+          str << "  * #{datasource}\n"
+        end
+
+        str << "\nFile lookup order:\n"
+        Config[:backends].each do |backend|
+          datadir = Backend.datadir(backend, scope)
+          next unless datadir
+
+          Backend.datasources(scope) do |source|
+            path = File.join(datadir, "#{source}.#{backend}")
+            str << "  * #{path}\n"
+          end
+        end
+
+        str
+      end
+
       def clear!
         @backends = {}
       end


### PR DESCRIPTION
This adds the explain option to describe how hiera would resolve
datasources. It re-orders argument parsing slightly so this can be run
on its own, or can be output prior to the data resolution being
displayed. Context is that people find hiera lookups fiendishly
non-intuitive, so having it rendered in plain text would hopefully make
the process more consumable.

Please don't merge as-is. I'd like feedback as to whether this line of
thought would be accepted into core rather than as an external script
like we use in the classroom. If so, I'll finish it and with tests and
better error handling and a puppet DSL function and the like.

This adds this type of functionality:

```
$ RUBYLIB=./lib bin/hiera --explain -c /etc/hiera.yaml fqdn=boo
Backend data directories:
  * yaml: /etc/puppetlabs/code/hieradata

Expanded hierarchy:
  * training.puppetlabs.vm
  * boo
  * defaults

File lookup order:
  * /etc/puppetlabs/code/hieradata/training.puppetlabs.vm.yaml
  * /etc/puppetlabs/code/hieradata/boo.yaml
  * /etc/puppetlabs/code/hieradata/defaults.yaml
```