### PR TITLE
(HI-274) Fix using non-existent Hiera#error

### DIFF
--- a/lib/hiera/config.rb
+++ b/lib/hiera/config.rb
@@ -54,8 +54,7 @@ class Hiera::Config
         begin
           require "deep_merge"
         rescue LoadError
-          Hiera.error "Must have 'deep_merge' gem installed for the configured merge_behavior."
-          raise
+          raise Hiera::Error, "Must have 'deep_merge' gem installed for the configured merge_behavior."
         end
       end
     end

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -72,6 +72,21 @@ class Hiera
           Config.load('/dev/null')
         end
       end
+
+      describe "if deep_merge can't be loaded" do
+        let(:error_message) { "Must have 'deep_merge' gem installed for the configured merge_behavior." }
+        before(:each) do
+          Config.expects(:require).with("deep_merge").raises(LoadError, "unable to load")
+        end
+
+        it "should error if merge_behavior is 'deep'" do
+          expect { Config.load(:merge_behavior => :deep) }.to raise_error(Hiera::Error, error_message)
+        end
+
+        it "should error if merge_behavior is 'deeper'" do
+          expect { Config.load(:merge_behavior => :deeper) }.to raise_error(Hiera::Error, error_message)
+        end
+      end
     end
 
     describe "#load_backends" do


### PR DESCRIPTION
Previous commit tried to use Hiera#error, which doesn't exist. Pattern
for errors is to raise an exception, so changed to raising an exception
if deep_merge is requested but unavailable. Added spec tests.