### PR TITLE
(maint) Add deep_merge gem install to git and packages pre-suite

### DIFF
--- a/acceptance_tests/setup/00_EnvSetup.rb
+++ b/acceptance_tests/setup/00_EnvSetup.rb
@@ -46,5 +46,11 @@ hosts.each do |host|
   when /solaris/
     step "#{host} Install json from rubygems"
     on host, 'gem install json'
+
+    step "#{host} Install deep_merge from rubygems"
+    on host, 'gem install deep_merge'
+  else
+    step "#{host} Install deep_merge from rubygems"
+    on host, 'gem install deep_merge'
   end
 end


### PR DESCRIPTION
Puppet 4.0 requires the deep_merge gem. It needs to be available when
running the acceptance suite on git or packages against Puppet (it is
included in aio).

This adds a 'gem install deep_merge' on all hosts (for the sake of
simplicity) except windows hosts (where it is not needed).