### PR TITLE
(maint) Make Puppet/Facter branches configurable for acceptance

### DIFF
--- a/acceptance_tests/Rakefile
+++ b/acceptance_tests/Rakefile
@@ -6,7 +6,7 @@ namespace :ci do
           "--load-path", "lib",
           "--hosts", ENV['CONFIG'],
           "--pre-suite", "setup",
-          "--install", "PUPPET/master,FACTER/master,HIERA/#{ENV['HIERA'] || 'master'}",
+          "--install", "PUPPET/#{ENV['PUPPET'] || 'master'},FACTER/#{ENV['FACTER'] || 'master'},HIERA/#{ENV['HIERA'] || 'master'}",
           "--tests", "tests",
           "--ntp",
           "--xml",


### PR DESCRIPTION
With Puppet 4.0, we're introducing a break between master and stable
across projects. For a while, Hiera stable should run agaist
Puppet/Facter stable.

Change the acceptance Rake task to make Puppet and Facter branches
configurable.