### PR TITLE
(HI-340) Fix hieradata path in acceptance tests

### DIFF
--- a/acceptance/tests/yaml_backend/00-setup.rb
+++ b/acceptance/tests/yaml_backend/00-setup.rb
@@ -1,14 +1,10 @@
 test_name "Hiera setup for YAML backend"
 
 agents.each do |agent|
+  codedir = agent.puppet['codedir']
+  hieradatadir = File.join(codedir, 'hieradata')
   apply_manifest_on agent, <<-PP
-file { '/etc/puppetlabs':
-  ensure  => directory,
-}->
-file { '/etc/puppetlabs/code':
-  ensure  => directory,
-}->
-file { '/etc/puppetlabs/code/hiera.yaml':
+file { '#{codedir}/hiera.yaml':
   ensure  => present,
   content => '---
     :backends:
@@ -20,11 +16,11 @@ file { '/etc/puppetlabs/code/hiera.yaml':
       - "global"
 
     :yaml:
-      :datadir: "#{agent['hieradatadir']}"
+      :datadir: "#{hieradatadir}"
   '
 }
 
-file { '#{agent['hieradatadir']}':
+file { '#{hieradatadir}':
   ensure  => directory,
   recurse => true,
   purge   => true,

--- a/acceptance/tests/yaml_backend/02-lookup_data_with_no_options.rb
+++ b/acceptance/tests/yaml_backend/02-lookup_data_with_no_options.rb
@@ -1,10 +1,12 @@
 begin test_name "Lookup data using the default options"
 
   agents.each do |agent|
+    codedir = agent.puppet['codedir']
+    hieradatadir = File.join(codedir, 'hieradata')
 
     step 'Setup'
       apply_manifest_on agent, <<-PP
-        file { '#{agent['hieradatadir']}':
+        file { '#{hieradatadir}':
           ensure  => directory,
           recurse => true,
           purge   => true,
@@ -13,7 +15,7 @@ begin test_name "Lookup data using the default options"
     PP
 
       apply_manifest_on agent, <<-PP
-        file { '#{agent['hieradatadir']}/global.yaml':
+        file { '#{hieradatadir}/global.yaml':
           ensure  => present,
           content => "---
             http_port: 8080

--- a/acceptance/tests/yaml_backend/04-lookup_data_with_array_search.rb
+++ b/acceptance/tests/yaml_backend/04-lookup_data_with_array_search.rb
@@ -1,37 +1,39 @@
 begin test_name "Lookup data with Array search"
 
   agents.each do |agent|
+    codedir = agent.puppet['codedir']
+    hieradatadir = File.join(codedir, 'hieradata')
 
     teardown do
       apply_manifest_on agent, <<-PP
-      file { '#{agent['hieradatadir']}':
+      file { '#{hieradatadir}':
         ensure  => directory,
         recurse => true,
         purge   => true,
         force   => true,
       }
-      file { '/etc/puppet/scope.yaml': ensure => absent }
-      file { '/etc/puppet/scope.json': ensure => absent }
+      file { '#{codedir}/scope.yaml': ensure => absent }
+      file { '#{codedir}/scope.json': ensure => absent }
       PP
     end
 
     step 'Setup'
       apply_manifest_on agent, <<-PP
-      file { '#{agent['hieradatadir']}/production.yaml':
+      file { '#{hieradatadir}/production.yaml':
         ensure  => present,
         content => "---
           ntpservers: ['production.ntp.puppetlabs.com']
         "
       }
 
-      file { '#{agent['hieradatadir']}/global.yaml':
+      file { '#{hieradatadir}/global.yaml':
         ensure  => present,
         content => "---
           ntpservers: ['global.ntp.puppetlabs.com']
         "
       }
 
-      file { '/etc/puppet/scope.yaml':
+      file { '#{codedir}/scope.yaml':
         ensure  => present,
         content => "---
           environment: production
@@ -40,7 +42,7 @@ begin test_name "Lookup data with Array search"
       PP
 
     step "Try to lookup data using array search"
-      on agent, hiera('ntpservers', '--yaml', '/etc/puppet/scope.yaml', '--array'),
+      on agent, hiera('ntpservers', '--yaml', "#{codedir}/scope.yaml", '--array'),
         :acceptable_exit_codes => [0] do
         assert_output <<-OUTPUT
           STDOUT> ["production.ntp.puppetlabs.com", "global.ntp.puppetlabs.com"]


### PR DESCRIPTION
Hieradata dir changed in hiera and hasn't been updated in beaker, so
tests fail because creating hieradata dir fails. To avoid this situation
in the future, we query Puppet for the location of codedir and derive
hieradata dir from it.