### PR TITLE
(HI-343) Fix hieradatadir path for AIO

### DIFF
--- a/acceptance/tests/yaml_backend/00-setup.rb
+++ b/acceptance/tests/yaml_backend/00-setup.rb
@@ -1,6 +1,8 @@
 test_name "Hiera setup for YAML backend"
 
 agents.each do |agent|
+  puppetcodedir = agent.puppet()[:codedir]
+  hieradatadir = "#{puppetcodedir}/hieradata"
   apply_manifest_on agent, <<-PP
 file { '/etc/puppetlabs':
   ensure  => directory,
@@ -20,11 +22,11 @@ file { '/etc/puppetlabs/code/hiera.yaml':
       - "global"
 
     :yaml:
-      :datadir: "#{agent['hieradatadir']}"
+      :datadir: "#{hieradatadir}"
   '
 }
 
-file { '#{agent['hieradatadir']}':
+file { '#{hieradatadir}':
   ensure  => directory,
   recurse => true,
   purge   => true,

--- a/acceptance/tests/yaml_backend/02-lookup_data_with_no_options.rb
+++ b/acceptance/tests/yaml_backend/02-lookup_data_with_no_options.rb
@@ -2,9 +2,12 @@ begin test_name "Lookup data using the default options"
 
   agents.each do |agent|
 
+    puppetcodedir = agent.puppet()[:codedir]
+    hieradatadir = "#{puppetcodedir}/hieradata"
+
     step 'Setup'
       apply_manifest_on agent, <<-PP
-        file { '#{agent['hieradatadir']}':
+        file { '#{hieradatadir}':
           ensure  => directory,
           recurse => true,
           purge   => true,
@@ -13,7 +16,7 @@ begin test_name "Lookup data using the default options"
     PP
 
       apply_manifest_on agent, <<-PP
-        file { '#{agent['hieradatadir']}/global.yaml':
+        file { '#{hieradatadir}/global.yaml':
           ensure  => present,
           content => "---
             http_port: 8080

--- a/acceptance/tests/yaml_backend/04-lookup_data_with_array_search.rb
+++ b/acceptance/tests/yaml_backend/04-lookup_data_with_array_search.rb
@@ -2,36 +2,39 @@ begin test_name "Lookup data with Array search"
 
   agents.each do |agent|
 
+    puppetcodedir = agent.puppet()[:codedir]
+    hieradatadir = "#{puppetcodedir}/hieradata"
+
     teardown do
       apply_manifest_on agent, <<-PP
-      file { '#{agent['hieradatadir']}':
+      file { '#{hieradatadir}':
         ensure  => directory,
         recurse => true,
         purge   => true,
         force   => true,
       }
-      file { '/etc/puppet/scope.yaml': ensure => absent }
-      file { '/etc/puppet/scope.json': ensure => absent }
+      file { '#{puppetcodedir}/scope.yaml': ensure => absent }
+      file { '#{puppetcodedir}/scope.json': ensure => absent }
       PP
     end
 
     step 'Setup'
       apply_manifest_on agent, <<-PP
-      file { '#{agent['hieradatadir']}/production.yaml':
+      file { '#{hieradatadir}/production.yaml':
         ensure  => present,
         content => "---
           ntpservers: ['production.ntp.puppetlabs.com']
         "
       }
 
-      file { '#{agent['hieradatadir']}/global.yaml':
+      file { '#{hieradatadir}/global.yaml':
         ensure  => present,
         content => "---
           ntpservers: ['global.ntp.puppetlabs.com']
         "
       }
 
-      file { '/etc/puppet/scope.yaml':
+      file { '#{puppetcodedir}/scope.yaml':
         ensure  => present,
         content => "---
           environment: production
@@ -40,7 +43,7 @@ begin test_name "Lookup data with Array search"
       PP
 
     step "Try to lookup data using array search"
-      on agent, hiera('ntpservers', '--yaml', '/etc/puppet/scope.yaml', '--array'),
+      on agent, hiera('ntpservers', '--yaml', "#{puppetcodedir}/scope.yaml", '--array'),
         :acceptable_exit_codes => [0] do
         assert_output <<-OUTPUT
           STDOUT> ["production.ntp.puppetlabs.com", "global.ntp.puppetlabs.com"]

--- a/acceptance/tests/yaml_backend/05-lookup_data_with_hash_search.rb
+++ b/acceptance/tests/yaml_backend/05-lookup_data_with_hash_search.rb
@@ -2,22 +2,25 @@ begin test_name "Lookup data with Hash search"
 
   agents.each do |agent|
 
+    puppetcodedir = agent.puppet()[:codedir]
+    hieradatadir = "#{puppetcodedir}/hieradata"
+
     teardown do
       apply_manifest_on agent, <<-PP
-      file { '#{agent['hieradatadir']}':
+      file { '#{hieradatadir}':
         ensure  => directory,
         recurse => true,
         purge   => true,
         force   => true,
       }
-      file { '/etc/puppet/scope.yaml': ensure => absent }
-      file { '/etc/puppet/scope.json': ensure => absent }
+      file { '#{puppetcodedir}/scope.yaml': ensure => absent }
+      file { '#{puppetcodedir}/scope.json': ensure => absent }
       PP
     end
 
     step 'Setup'
       apply_manifest_on agent, <<-PP
-      file { '#{agent['hieradatadir']}/production.yaml':
+      file { '#{hieradatadir}/production.yaml':
         ensure  => present,
         content => "---
           users:
@@ -26,7 +29,7 @@ begin test_name "Lookup data with Hash search"
         "
       }
 
-      file { '#{agent['hieradatadir']}/global.yaml':
+      file { '#{hieradatadir}/global.yaml':
         ensure  => present,
         content => "---
           users:
@@ -35,7 +38,7 @@ begin test_name "Lookup data with Hash search"
         "
       }
 
-      file { '/etc/puppet/scope.yaml':
+      file { '#{puppetcodedir}/scope.yaml':
         ensure  => present,
         content => "---
           environment: production
@@ -44,7 +47,7 @@ begin test_name "Lookup data with Hash search"
       PP
 
     step "Try to lookup data using hash search"
-      on agent, hiera('users', '--yaml', '/etc/puppet/scope.yaml', '--hash'),
+      on agent, hiera('users', '--yaml', "#{puppetcodedir}/scope.yaml", '--hash'),
         :acceptable_exit_codes => [0] do
         assert_match /joe[^}]+"uid"=>1000}/, result.output
         assert_match /pete[^}]+"uid"=>1001}/, result.output


### PR DESCRIPTION
This commit derived the hieradatadir from the :codedir of the agent under
test.
 
This will allow the tests to pass using the AIO even when the Beaker config
does not explicitly define that type.