### PR TITLE
(HI-298) Move hiera data to C:\ProgramData\PuppetLabs\code

### DIFF
--- a/ext/hiera.yaml
+++ b/ext/hiera.yaml
@@ -10,6 +10,6 @@
 :yaml:
 # datadir is empty here, so hiera uses its defaults:
 # - /etc/puppetlabs/code/hieradata on *nix
-# - %CommonAppData%\PuppetLabs\hiera\var on Windows
+# - %CommonAppData%\PuppetLabs\code\hieradata on Windows
 # When specifying a datadir, make sure the directory exists.
   :datadir:

--- a/lib/hiera/util.rb
+++ b/lib/hiera/util.rb
@@ -9,7 +9,7 @@ class Hiera
 
     def microsoft_windows?
       return false unless file_alt_separator
-      
+
       begin
         require 'win32/dir'
         true
@@ -21,7 +21,7 @@ class Hiera
 
     def config_dir
       if microsoft_windows?
-         File.join(common_appdata, 'PuppetLabs', 'hiera', 'etc')
+         File.join(common_appdata, 'PuppetLabs', 'code')
       else
         '/etc/puppetlabs/code'
       end
@@ -29,7 +29,7 @@ class Hiera
 
     def var_dir
       if microsoft_windows?
-        File.join(common_appdata, 'PuppetLabs', 'hiera', 'var')
+        File.join(common_appdata, 'PuppetLabs', 'code', 'hieradata')
       else
         '/etc/puppetlabs/code/hieradata'
       end

--- a/spec/unit/util_spec.rb
+++ b/spec/unit/util_spec.rb
@@ -29,7 +29,7 @@ describe Hiera::Util do
     it 'should return the correct path for microsoft windows systems' do
       Hiera::Util.expects(:microsoft_windows?).returns(true)
       Hiera::Util.expects(:common_appdata).returns('C:\\ProgramData')
-      Hiera::Util.config_dir.should == 'C:\\ProgramData/PuppetLabs/hiera/etc'
+      Hiera::Util.config_dir.should == 'C:\\ProgramData/PuppetLabs/code'
     end
   end
 
@@ -42,7 +42,7 @@ describe Hiera::Util do
     it 'should return the correct path for microsoft windows systems' do
       Hiera::Util.expects(:microsoft_windows?).returns(true)
       Hiera::Util.expects(:common_appdata).returns('C:\\ProgramData')
-      Hiera::Util.var_dir.should == 'C:\\ProgramData/PuppetLabs/hiera/var'
+      Hiera::Util.var_dir.should == 'C:\\ProgramData/PuppetLabs/code/hieradata'
     end
   end
 end


### PR DESCRIPTION
Previously, hiera on Windows defaulted to
C:\ProgramData\PuppetLabs\hiera\etc.

This commit updates hiera to use C:\ProgramData\PuppetLabs\code.