### PR TITLE
(maint) HI-345 fix hiera pre-suite for aio

### DIFF
--- a/acceptance/config/aio/options.rb
+++ b/acceptance/config/aio/options.rb
@@ -1,6 +1,8 @@
 {
   :type => 'aio',
+  :puppetbindir => '/opt/puppetlabs/puppet/bin',
   :pre_suite => [
     'setup/aio/pre-suite/010_Install.rb',
+    'setup/aio/pre-suite/020_AIO_Workarounds.rb',
   ],
 }

--- a/acceptance/setup/aio/pre-suite/020_AIO_Workarounds.rb
+++ b/acceptance/setup/aio/pre-suite/020_AIO_Workarounds.rb
@@ -1,0 +1,29 @@
+test_name 'temporary aio workarounds: ensure puppet and friends are on the path'
+
+step 'setup the symbolic links that aio packaging is not yet providing'
+puppet_bindir = options[:puppetbindir]
+new_puppet_bindir = '/opt/puppetlabs/bin'
+agents.each do |agent|
+  # stick current puppet hard-path in the ... PATH so we can use configprint
+  agent.add_env_var('PATH', "#{puppet_bindir}/puppet:$PATH")
+  on(agent, "mkdir #{new_puppet_bindir}")
+  on(agent, "ln -s #{puppet_bindir}/puppet " \
+            "#{new_puppet_bindir}/puppet")
+  on(agent, "ln -s #{puppet_bindir}/hiera " \
+            "#{new_puppet_bindir}/hiera")
+  on(agent, "ln -s #{puppet_bindir}/facter " \
+            "#{new_puppet_bindir}/facter")
+  agent.add_env_var('PATH', "#{new_puppet_bindir}:$PATH")
+end
+
+# The AIO puppet-agent package does not create the puppet user or group, but
+# puppet-server does. However, some puppet acceptance tests assume the user
+# is present. This is a temporary setup step to create the puppet user and
+# group, but only on nodes that are agents and not the master
+step '(PUP-3997) Puppet User and Group on agents only'
+agents.each do |agent|
+  step "Ensure puppet user and group added to #{agent}" do
+    on(agent, puppet('resource user puppet ensure=present'))
+    on(agent, puppet('resource group puppet ensure=present'))
+  end
+end


### PR DESCRIPTION
Before this change the hiera pre-suite could not run puppet to configure
tests properly.
This change creates temporary work-arounds until the aio packaging
creates and links binaries into the path properly.