### PR TITLE
(maint) Allow beaker version to be overridden

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -1,6 +1,16 @@
 source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
-gem "beaker", "~> 2.2.0"
+def location_for(place, fake_version = nil)
+  if place =~ /^(git:[^#]*)#(.*)/
+    [fake_version, { :git => $1, :branch => $2, :require => false }].compact
+  elsif place =~ /^file:\/\/(.*)/
+    ['>= 0', { :path => File.expand_path($1), :require => false }]
+  else
+    [place, { :require => false }]
+  end
+end
+
+gem "beaker", *location_for(ENV['BEAKER_VERSION'] || 'git://github.com/puppetlabs/beaker#master')
 gem 'rake', "~> 10.1.0"
 
 if File.exists? "#{__FILE__}.local"


### PR DESCRIPTION
Allow beaker gem version to be overridden as an environment variable,
e.g. export BEAKER_VERSION=git://github.com/puppetlabs/beaker#<sha>

This also changes the default beaker version from ~> 2.2.0 to the master
branch for now.