### PR TITLE
(HI-348) Enable deep-merge options to be passed in lookup

### DIFF
--- a/lib/hiera.rb
+++ b/lib/hiera.rb
@@ -49,15 +49,67 @@ class Hiera
 
   # Calls the backends to do the actual lookup.
   #
-  # The scope can be anything that responds to [], if you have input
+  # The _scope_ can be anything that responds to `[]`, if you have input
   # data like a Puppet Scope that does not you can wrap that data in a
-  # class that has a [] method that fetches the data from your source.
+  # class that has a `[]` method that fetches the data from your source.
   # See hiera-puppet for an example of this.
   #
   # The order-override will insert as first in the hierarchy a data source
   # of your choice.
+  #
+  # Possible values for the _resolution_type_ parameter:
+  #
+  # - _:priority_ - This is the default. First found value is returned and no merge is performed
+  # - _:array_ - An array merge lookup assembles a value from every matching level of the hierarchy. It retrieves all
+  #     of the (string or array) values for a given key, then flattens them into a single array of unique values.
+  #     If _priority_ lookup can be thought of as a “default with overrides” pattern, _array_ merge lookup can be though
+  #     of as “default with additions.”
+  # - _:hash_ - A hash merge lookup assembles a value from every matching level of the hierarchy. It retrieves all of
+  #     the (hash) values for a given key, then merges the hashes into a single hash. Hash merge lookups will fail with
+  #     an error if any of the values found in the data sources are strings or arrays. It only works when every value
+  #     found is a hash. The actual merge behavior is determined by looking up the keys `:merge_behavior` and
+  #     `:deep_merge_options` in the Hiera config. `:merge_behavior` can be set to `:deep`, :deeper` or `:native`
+  #     (explained in detail below).
+  # - _{ deep merge options }_ - Configured values for `:merge_behavior` and `:deep_merge_options`will be completely
+  #     ignored. Instead the _resolution_type_ will be a `:hash` merge where the `:merge_behavior` will be the value
+  #     keyed by `:behavior` in the given hash and the `:deep_merge_options` will be the remaining top level entries of
+  #     that same hash.
+  #
+  # Valid behaviors for the _:hash_ resolution type:
+  #
+  # - _native_ - Performs a simple hash-merge by overwriting keys of lower lookup priority.
+  # - _deeper_ - In a deeper hash merge, Hiera recursively merges keys and values in each source hash. For each key,
+  #     if the value is:
+  #        - only present in one source hash, it goes into the final hash.
+  #        - a string/number/boolean and exists in two or more source hashes, the highest priority value goes into
+  #          the final hash.
+  #        - an array and exists in two or more source hashes, the values from each source are merged into a single
+  #          array and de-duplicated (but not automatically flattened, as in an array merge lookup).
+  #        - a hash and exists in two or more source hashes, the values from each source are recursively merged, as
+  #          though they were source hashes.
+  #        - mismatched between two or more source hashes, we haven’t validated the behavior. It should act as
+  #          described in the deep_merge gem documentation.
+  # - _deep_ - In a deep hash merge, Hiera behaves the same as for _deeper_, except that when a string/number/boolean
+  #     exists in two or more source hashes, the lowest priority value goes into the final hash. This is considered
+  #     largely useless and should be avoided. Use _deeper_ instead.
+  #
+  # The _merge_ can be given as a hash with the mandatory key `:strategy` to denote the actual strategy. This
+  # is useful for the `:deeper` and `:deep` strategy since they can use additional options to control the behavior.
+  # The options can be passed as top level keys in the `merge` parameter when it is a given as a hash. Recognized
+  # options are:
+  #
+  #  - 'knockout_prefix' Set to string value to signify prefix which deletes elements from existing element. Defaults is _undef_
+  #  - 'sort_merged_arrays' Set to _true_ to sort all arrays that are merged together. Default is _false_
+  #  - 'unpack_arrays' Set to string value used as a deliminator to join all array values and then split them again. Default is _undef_
+  #  - 'merge_hash_arrays' Set to _true_ to merge hashes within arrays. Default is _false_
+  #
+  # @param key [String] The key to lookup
+  # @param default [Object,nil] The value to return when there is no match for _key_
+  # @param scope [#[],nil] The scope to use for the lookup
+  # @param order_override [#[]] An override that will considered the first source of lookup
+  # @param resolution_type [String,Hash<Symbol,String>] Symbolic resolution type or deep merge configuration
+  # @return [Object] The found value or the given _default_ value
   def lookup(key, default, scope, order_override=nil, resolution_type=:priority)
     Backend.lookup(key, default, scope, order_override, resolution_type)
   end
 end
-

--- a/lib/hiera/backend/json_backend.rb
+++ b/lib/hiera/backend/json_backend.rb
@@ -36,7 +36,7 @@ class Hiera
           #
           # for priority searches we break after the first found data item
           new_answer = Backend.parse_answer(data[key], scope, {}, context)
-          case resolution_type
+          case resolution_type.is_a?(Hash) ? :hash : resolution_type
           when :array
             raise Exception, "Hiera type mismatch for key '#{key}': expected Array and got #{new_answer.class}" unless new_answer.kind_of? Array or new_answer.kind_of? String
             answer ||= []
@@ -44,7 +44,7 @@ class Hiera
           when :hash
             raise Exception, "Hiera type mismatch for key '#{key}': expected Hash and got #{new_answer.class}" unless new_answer.kind_of? Hash
             answer ||= {}
-            answer = Backend.merge_answer(new_answer,answer)
+            answer = Backend.merge_answer(new_answer, answer, resolution_type)
           else
             answer = new_answer
             break

--- a/lib/hiera/backend/yaml_backend.rb
+++ b/lib/hiera/backend/yaml_backend.rb
@@ -35,7 +35,7 @@ class Hiera
           #
           # for priority searches we break after the first found data item
           new_answer = Backend.parse_answer(data[key], scope, {}, context)
-          case resolution_type
+          case resolution_type.is_a?(Hash) ? :hash : resolution_type
           when :array
             raise Exception, "Hiera type mismatch for key '#{key}': expected Array and got #{new_answer.class}" unless new_answer.kind_of? Array or new_answer.kind_of? String
             answer ||= []
@@ -43,7 +43,7 @@ class Hiera
           when :hash
             raise Exception, "Hiera type mismatch for key '#{key}': expected Hash and got #{new_answer.class}" unless new_answer.kind_of? Hash
             answer ||= {}
-            answer = Backend.merge_answer(new_answer,answer)
+            answer = Backend.merge_answer(new_answer, answer, resolution_type)
           else
             answer = new_answer
             break

--- a/spec/unit/backend_spec.rb
+++ b/spec/unit/backend_spec.rb
@@ -722,6 +722,17 @@ class Hiera
         Backend.merge_answer({"a" => "answer"},{"b" => "bnswer"}).should == {"a" => "answer", "b" => "bnswer"}
       end
 
+      it "disregards configuration when 'merge' parameter is given as a Hash" do
+        Config.load({:merge_behavior => :deep})
+        Hash.any_instance.expects('deep_merge!').with({"b" => "bnswer"}, {}).returns({"a" => "answer", "b" => "bnswer"})
+        Backend.merge_answer({"a" => "answer"},{"b" => "bnswer"}, {:behavior => 'deeper' }).should == {"a" => "answer", "b" => "bnswer"}
+      end
+
+      it "propagates deep merge options when given Hash 'merge' parameter" do
+        Hash.any_instance.expects('deep_merge!').with({"b" => "bnswer"}, { :knockout_prefix => '-' }).returns({"a" => "answer", "b" => "bnswer"})
+        Backend.merge_answer({"a" => "answer"},{"b" => "bnswer"}, {:behavior => 'deeper', :knockout_prefix => '-'}).should == {"a" => "answer", "b" => "bnswer"}
+      end
+
       it "passes Config[:deep_merge_options] into calls to deep_merge" do
         Config.load({:merge_behavior => :deep, :deep_merge_options => { :knockout_prefix => '-' } })
         Hash.any_instance.expects('deep_merge').with({"b" => "bnswer"}, {:knockout_prefix => '-'}).returns({"a" => "answer", "b" => "bnswer"})


### PR DESCRIPTION
Prior to this commit it was not possible to provide deep merge options
in each call. The only way to use such options was to configure them
globally in the Hiera config. This commit changes this by allowing
the 'resolution_type' parameter to be a Hash and also ensure that is
propagated to the Backend::merge_answer() method.

When the 'resolution_type' is a hash, the merge_answer method will
completely disregard the Hiera deep merge config and instead pick the
merge behavior (keyed by :behavior) from the hash and consider the
deep merge options to the remaining top level entries of the hash.