### PR TITLE
(maint) Load packaging and spec tasks separately

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,16 @@
+# These two need to be loaded sperately.
+# If we load packaging.rake first, and it isn't available,
+# running `rake spec` in a bare repo will fail since neither
+# rubygems nor `rake_task` will have loaded. However, when we load
+# packaging.rake last, package building fails.
+begin
+  load File.join(File.dirname(__FILE__), 'ext', 'packaging', 'packaging.rake')
+rescue LoadError
+end
+
 begin
   require 'rubygems'
   require 'rspec/core/rake_task'
-  load File.join(File.dirname(__FILE__), 'ext', 'packaging', 'packaging.rake')
 rescue LoadError
 end
 


### PR DESCRIPTION
When building packaging on jenkins, we don't have the rake library
available. Because of this, we try to load it in our Rakefile, it fails,
and then it bombs out and doesn't load anything else (aka the rake tasks
we use for packaging).

Since we also need to load rubygems and rspec/core/rake_task when
running `rake spec`. We need to be able to run spec tests in a repo
where the packaging repo hasn't been cloned and packaging.rake isn't
available. So we need to load these two different sets of libraries
separately.