### PR TITLE
(maint) Remove Fedora 19 from build targets

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -9,7 +9,7 @@ gpg_name: 'info@puppetlabs.com'
 gpg_key: '4BD6EC30'
 sign_tar: FALSE
 # a space separated list of mock configs
-final_mocks: 'pl-el-5-i386 pl-el-6-i386 pl-el-7-x86_64 pl-fedora-19-i386 pl-fedora-20-i386'
+final_mocks: 'pl-el-5-i386 pl-el-6-i386 pl-el-7-x86_64 pl-fedora-20-i386'
 build_gem: TRUE
 build_dmg: TRUE
 yum_host: 'yum.puppetlabs.com'


### PR DESCRIPTION
Fedora 19 went EOL on 2015-01-06. We should not longer be providing
packages for this platform.