### PR TITLE
(HI-372) Do lazy eval of logger messages

### DIFF
--- a/lib/hiera.rb
+++ b/lib/hiera.rb
@@ -31,8 +31,13 @@ class Hiera
       warn("Failed to load #{logger} logger: #{e.class}: #{e}")
     end
 
-    def warn(msg); @logger.warn(msg); end
-    def debug(msg); @logger.debug(msg); end
+    def warn(msg = '', &block)
+      block_given? ? @logger.debug(&block) : @logger.debug(msg)
+    end
+
+    def debug(msg = '', &block)
+      block_given? ? @logger.debug(&block) : @logger.debug(msg)
+    end
   end
 
   attr_reader :options, :config


### PR DESCRIPTION
Avoid evaluating log code when it's not desirable, to achieve this the user
need to pass a block to the log function instead of a string.

E.g.:

 # Bad, 'some_slow_function' is always called.
 Hiera.debug "Hey #{some_slow_function}"

 # Good, nothing evaluated.
 Hiera.debug { "Hey #{some_slow_function}" }

Old behavior still supported.