### PR TITLE
(HI-374) configure hiera to work out of the box

### DIFF
--- a/ext/hiera.yaml
+++ b/ext/hiera.yaml
@@ -2,14 +2,12 @@
 :backends:
   - yaml
 :hierarchy:
-  - defaults
-  - "%{clientcert}"
-  - "%{environment}"
-  - global
+  - "nodes/%{::trusted.certname}"
+  - common
 
 :yaml:
 # datadir is empty here, so hiera uses its defaults:
-# - /etc/puppetlabs/code/hieradata on *nix
-# - %CommonAppData%\PuppetLabs\code\hieradata on Windows
+# - /etc/puppetlabs/code/environments/%{environment}/hieradata on *nix
+# - %CommonAppData%\PuppetLabs\code\environments\%{environment}\hieradata on Windows
 # When specifying a datadir, make sure the directory exists.
   :datadir:

--- a/lib/hiera/util.rb
+++ b/lib/hiera/util.rb
@@ -29,9 +29,9 @@ class Hiera
 
     def var_dir
       if microsoft_windows?
-        File.join(common_appdata, 'PuppetLabs', 'code', 'hieradata')
+        File.join(common_appdata, 'PuppetLabs', 'code', 'environments' , '%{environment}' , 'hieradata')
       else
-        '/etc/puppetlabs/code/hieradata'
+        '/etc/puppetlabs/code/environments/%{environment}/hieradata'
       end
     end
 

--- a/spec/unit/backend_spec.rb
+++ b/spec/unit/backend_spec.rb
@@ -22,13 +22,13 @@ class Hiera
 
       it "defaults to a directory in var" do
         Config.load({})
-        Backend.datadir(:rspec, {}).should == Hiera::Util.var_dir
+        Backend.datadir(:rspec, { "environment" => "foo" }).should == Hiera::Util.var_dir % { :environment => "foo"}
 
         Config.load({:rspec => nil})
-        Backend.datadir(:rspec, {}).should == Hiera::Util.var_dir
+        Backend.datadir(:rspec, { "environment" => "foo" }).should == Hiera::Util.var_dir % { :environment => "foo"}
 
         Config.load({:rspec => {}})
-        Backend.datadir(:rspec, {}).should == Hiera::Util.var_dir
+        Backend.datadir(:rspec, { "environment" => "foo" }).should == Hiera::Util.var_dir % { :environment => "foo"}
       end
 
       it "fails when the datadir is an array" do

--- a/spec/unit/util_spec.rb
+++ b/spec/unit/util_spec.rb
@@ -36,13 +36,13 @@ describe Hiera::Util do
   describe 'Hiera::Util.var_dir' do
     it 'should return the correct path for posix systems' do
       Hiera::Util.expects(:file_alt_separator).returns(nil)
-      Hiera::Util.var_dir.should == '/etc/puppetlabs/code/hieradata'
+      Hiera::Util.var_dir.should == '/etc/puppetlabs/code/environments/%{environment}/hieradata'
     end
 
     it 'should return the correct path for microsoft windows systems' do
       Hiera::Util.expects(:microsoft_windows?).returns(true)
       Hiera::Util.expects(:common_appdata).returns('C:\\ProgramData')
-      Hiera::Util.var_dir.should == 'C:\\ProgramData/PuppetLabs/code/hieradata'
+      Hiera::Util.var_dir.should == 'C:\\ProgramData/PuppetLabs/code/environments/%{environment}/hieradata'
     end
   end
 end


### PR DESCRIPTION
Prior to this commit, users had to configure hiera.yaml
before being able to use hiera. This commit defines a datadir
and a basic hierarchy to make it easier for users to get up
and running.

please see PE-894