### PR TITLE
removed defaults from hiera.yaml

### DIFF
--- a/ext/hiera.yaml
+++ b/ext/hiera.yaml
@@ -2,7 +2,6 @@
 :backends:
   - yaml
 :hierarchy:
-  - defaults
   - "%{clientcert}"
   - "%{environment}"
   - global


### PR DESCRIPTION

This is something that has irritated me for a long time now, and something I have to explain every time I run a training course or demo hiera "out of the box"...   The default hiera.yaml file has a static hierarchy entry of "default" as the first element.    This is confusing to users.  "default" implies that the value will be used if it has not been declared elsewhere, when in fact, the opposite is true - a better name would be "overrides" since anything at this level will override any other data.   Whereas, true "defaults" actually live in "global".

I think it is best completely removed as it goes against the whole concept of hierarchical overriding....

