### PR TITLE
(maint) [skip ci] Add puppet-agent 1.2.0 platforms

### DIFF
--- a/acceptance/config/nodes/osx-1010-x86_64.yaml
+++ b/acceptance/config/nodes/osx-1010-x86_64.yaml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  master:
+    roles:
+    - master
+    platform: el-7-x86_64
+    hypervisor: vcloud
+    template: redhat-7-x86_64
+  agent:
+    roles:
+    - agent
+    platform: osx-yosemite-x86_64
+    hypervisor: vcloud
+    template: osx-1010-x86_64
+CONFIG:
+  datastore: instance0
+  resourcepool: delivery/Quality Assurance/FOSS/Dynamic
+  folder: Delivery/Quality Assurance/FOSS/Dynamic
+  pooling_api: http://vmpooler.delivery.puppetlabs.net/

--- a/acceptance/config/nodes/osx-109-x86_64.yaml
+++ b/acceptance/config/nodes/osx-109-x86_64.yaml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  master:
+    roles:
+    - master
+    platform: el-7-x86_64
+    hypervisor: vcloud
+    template: redhat-7-x86_64
+  agent:
+    roles:
+    - agent
+    platform: osx-mavericks-x86_64
+    hypervisor: vcloud
+    template: osx-109-x86_64
+CONFIG:
+  datastore: instance0
+  resourcepool: delivery/Quality Assurance/FOSS/Dynamic
+  folder: Delivery/Quality Assurance/FOSS/Dynamic
+  pooling_api: http://vmpooler.delivery.puppetlabs.net/

--- a/acceptance/config/nodes/ubuntu-1504-i386.yaml
+++ b/acceptance/config/nodes/ubuntu-1504-i386.yaml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  master:
+    roles:
+    - master
+    platform: el-7-x86_64
+    hypervisor: vcloud
+    template: redhat-7-x86_64
+  agent:
+    roles:
+    - agent
+    platform: ubuntu-vivid-i386
+    hypervisor: vcloud
+    template: ubuntu-1504-i386
+CONFIG:
+  datastore: instance0
+  resourcepool: delivery/Quality Assurance/FOSS/Dynamic
+  folder: Delivery/Quality Assurance/FOSS/Dynamic
+  pooling_api: http://vmpooler.delivery.puppetlabs.net/

--- a/acceptance/config/nodes/ubuntu-1504-x86_64.yaml
+++ b/acceptance/config/nodes/ubuntu-1504-x86_64.yaml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  master:
+    roles:
+    - master
+    platform: el-7-x86_64
+    hypervisor: vcloud
+    template: redhat-7-x86_64
+  agent:
+    roles:
+    - agent
+    platform: ubuntu-vivid-x86_64
+    hypervisor: vcloud
+    template: ubuntu-1504-x86_64
+CONFIG:
+  datastore: instance0
+  resourcepool: delivery/Quality Assurance/FOSS/Dynamic
+  folder: Delivery/Quality Assurance/FOSS/Dynamic
+  pooling_api: http://vmpooler.delivery.puppetlabs.net/


### PR DESCRIPTION
These are testing configs for the platforms that will be added to puppet-agent 1.2.0

They are the same files from puppetlabs/puppet#3972 and puppetlabs/puppet#3971 and puppetlabs/facter#962