### PR TITLE
(HI-369) Remove mock and cow build targets

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -1,23 +1,21 @@
 ---
 packaging_url: 'git://github.com/puppetlabs/packaging.git --branch=master'
 packaging_repo: 'packaging'
-default_cow: 'base-squeeze-i386.cow'
-cows: 'base-precise-i386.cow base-squeeze-i386.cow base-stable-i386.cow base-testing-i386.cow base-trusty-i386.cow base-wheezy-i386.cow'
-pbuild_conf: '/etc/pbuilderrc'
 packager: 'puppetlabs'
-gpg_name: 'info@puppetlabs.com'
 gpg_key: '4BD6EC30'
-sign_tar: FALSE
-# a space separated list of mock configs
-final_mocks: 'pl-el-5-i386 pl-el-6-i386 pl-el-7-x86_64 pl-fedora-20-i386'
+
+# These are the build targets used by the packaging repo. Uncomment to allow use.
+#final_mocks: 'pl-el-5-i386 pl-el-6-i386 pl-el-7-x86_64'
+#default_cow: 'base-trusty-i386.cow'
+#cows: 'base-precise-i386.cow base-squeeze-i386.cow base-trusty-i386.cow base-wheezy-i386.cow'
+#pbuild_conf: '/etc/pbuilderrc'
+
 build_gem: TRUE
-build_dmg: TRUE
+build_dmg: FALSE
+sign_tar: FALSE
 yum_host: 'yum.puppetlabs.com'
 yum_repo_path: '/opt/repository/yum/'
 apt_host: 'apt.puppetlabs.com'
 apt_repo_url: 'http://apt.puppetlabs.com'
 apt_repo_path: '/opt/repository/incoming'
-ips_repo: '/var/pkgrepo'
-ips_store: '/opt/repository'
-ips_host: 'solaris-11-ips-repo.acctest.dc1.puppetlabs.net'
 tar_host: 'downloads.puppetlabs.com'


### PR DESCRIPTION
With the switch over to delivering software via the puppet agent
packages, we no longer need to maintain this list of build targets for
use by the packaging repo automation. We do want to keep some of this
around and available in the off chance that a community member has the
desire to build their own packages using the packaging repo automation.