### PR TITLE
(maint) Install dmg during osx acceptance

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -10,7 +10,7 @@ def location_for(place, fake_version = nil)
   end
 end
 
-gem "beaker", *location_for(ENV['BEAKER_VERSION'] || 'git://github.com/puppetlabs/beaker#master')
+gem "beaker", *location_for(ENV['BEAKER_VERSION'] || "~> 2.16")
 gem 'rake', "~> 10.1.0"
 
 if File.exists? "#{__FILE__}.local"

--- a/acceptance/setup/aio/pre-suite/010_Install.rb
+++ b/acceptance/setup/aio/pre-suite/010_Install.rb
@@ -33,11 +33,19 @@ PACKAGES = {
 install_packages_on(hosts, PACKAGES)
 
 agents.each do |agent|
-  if agent['platform'] =~ /windows/
+  case agent['platform']
+  when /windows/
     arch = agent[:ruby_arch] || 'x86'
     base_url = ENV['MSI_BASE_URL'] || "http://builds.puppetlabs.lan/puppet-agent/#{ENV['SHA']}/artifacts/windows"
     filename = ENV['MSI_FILENAME'] || "puppet-agent-#{arch}.msi"
 
     install_puppet_from_msi(agent, :url => "#{base_url}/#{filename}")
+  when /osx/
+    opts = {
+      :puppet_collection => 'PC1',
+      :puppet_agent_sha => ENV['SHA'],
+      :puppet_agent_version => ENV['SUITE_VERSION'] || ENV['SHA']
+    }
+    install_puppet_agent_dev_repo_on(agent, opts)
   end
 end


### PR DESCRIPTION
Installs puppet-agent dmg on osx during aio acceptance, which depends on
beaker 2.16 or later.