### PR TITLE
(HI-184) Inconsistent handling of fully-qualified facts when called from the command line [#puppethack]

### DIFF
--- a/acceptance/tests/test-184-command-line-facts.rb
+++ b/acceptance/tests/test-184-command-line-facts.rb
@@ -1,0 +1,66 @@
+test_name "Command-line lookup should resolve based on fact values from facter run"
+
+agents.each do |agent|
+  codedir = agent.puppet['codedir']
+  hieradatadir = File.join(codedir, 'hieradata')
+
+  teardown do
+    apply_manifest_on agent, <<-PP
+    file { '#{hieradatadir}':
+      ensure  => directory,
+      recurse => true,
+      purge   => true,
+      force   => true,
+    }
+    file { '#{codedir}/scope.yaml': ensure => absent }
+    file { '#{codedir}/scope.json': ensure => absent }
+    PP
+  end
+
+  osfamily = (on agent, facter('osfamily')).stdout.chomp
+
+  apply_manifest_on agent, <<-PP
+file { '#{codedir}/hiera.yaml':
+  ensure  => present,
+  content => '---
+    :backends:
+      - "yaml"
+    :logger: "console"
+    :hierarchy:
+      - "osfamily/%{::osfamily}"
+      - "%{environment}"
+      - "global"
+
+    :yaml:
+      :datadir: "#{hieradatadir}"
+  '
+}
+
+file { ['#{hieradatadir}', '#{hieradatadir}/osfamily']:
+  ensure => directory,
+}
+
+file { '#{hieradatadir}/global.yaml':
+  ensure => present,
+  content => "---
+    foo: zan
+  "
+}
+
+file { '#{hieradatadir}/osfamily/#{osfamily}.yaml':
+  ensure => present,
+  content => "---
+    foo: bar
+  "
+}
+PP
+
+  on agent, hiera('foo', "osfamily=#{osfamily}") do
+    assert_match /bar/, result.stdout
+  end
+
+  on agent, hiera('foo', "::osfamily=#{osfamily}") do
+    assert_match /bar/, result.stdout
+  end
+
+end

--- a/acceptance/ubuntu.yaml
+++ b/acceptance/ubuntu.yaml
@@ -1,0 +1,10 @@
+# Docker
+HOSTS:
+  ubuntu:
+    platform: ubuntu-14.04-x64
+    image: ubuntu
+    hypervisor: docker
+    roles:
+    - agent
+CONFIG:
+  type: foss

--- a/lib/hiera/backend.rb
+++ b/lib/hiera/backend.rb
@@ -307,8 +307,19 @@ class Hiera
 
       def qualified_lookup(segments, hash)
         value = hash
+
         segments.each do |segment|
           throw :no_such_key if value.nil?
+          if segment =~ /^::(.+)/
+            othersegment = $1
+          else
+            othersegment = "::%s" % segment
+          end
+
+          if value.include?(othersegment)
+            value[segment] = value[othersegment]
+          end
+
           if segment =~ /^[0-9]+$/
             segment = segment.to_i
             raise Exception, "Hiera type mismatch: Got #{value.class.name} when Array was expected enable lookup using key '#{segment}'" unless value.instance_of?(Array)

--- a/spec/unit/backend_spec.rb
+++ b/spec/unit/backend_spec.rb
@@ -212,12 +212,12 @@ class Hiera
       end
 
       @leading_double_colon_tests = {
-        "test_%{::rspec::data}_test" => "test__test",
-        "test_%{scope('::rspec::data')}_test" => "test__test"
+        "test_%{::rspec::data}_test" => "test_value_test",
+        "test_%{scope('::rspec::data')}_test" => "test_value_test"
       }
 
       @leading_double_colon_tests.each do |input, expected|
-        it "does not try removing leading :: when a full lookup fails (#17434)" do
+        it "does find a matching key with leading :: when a full lookup fails (#17434)" do
           expect(Backend.parse_string(input, {"rspec::data" => "value"})).to eq(expected)
         end
       end

--- a/tmp/hiera/common.yaml
+++ b/tmp/hiera/common.yaml
@@ -1,0 +1,2 @@
+---
+key: Commonvalue

--- a/tmp/hiera/hiera.yaml
+++ b/tmp/hiera/hiera.yaml
@@ -1,0 +1,6 @@
+:hierarchy:
+  - "osfamily_%{::osfamily}"
+  - "%{::fqdn}"
+  - common
+:yaml:
+   :datadir: /var/hiera

--- a/tmp/hiera/host.example.com.yaml
+++ b/tmp/hiera/host.example.com.yaml
@@ -1,0 +1,2 @@
+---
+key: Hostvalue

--- a/tmp/hiera/osfamily_RedHat.yaml
+++ b/tmp/hiera/osfamily_RedHat.yaml
@@ -1,0 +1,2 @@
+---
+key: RedHatvalue

--- a/tmp/hiera/other.yaml
+++ b/tmp/hiera/other.yaml
@@ -1,0 +1,2 @@
+---
+key: Othervalue

--- a/tmp/setup
+++ b/tmp/setup
@@ -1,0 +1,4 @@
+#!/bin/sh
+sudo mkdir /var/hiera
+sudo chown $USER /var/hiera
+cp tmp/hiera/* /var/hiera

--- a/tmp/test
+++ b/tmp/test
@@ -1,0 +1,47 @@
+#!/bin/sh
+HIERA='bundle exec bin/hiera -c /var/hiera/hiera.yaml'
+
+echo ""
+echo "Basic test, no scope"
+echo -n "expect Commonvalue: got "
+$HIERA key
+
+echo ""
+echo "osfamily=Debian"
+echo -n "expect Commonvalue: got "
+$HIERA key osfamily=Debian
+
+echo ""
+echo "osfamily=RedHat"
+echo -n "expect RedHatvalue: got "
+$HIERA key osfamily=RedHat
+
+echo ""
+echo "fqdn=other"
+echo -n "expect Othervalue: got "
+$HIERA key fqdn=other
+
+echo ""
+echo "fqdn=host.example.com"
+echo -n "expect Commonvalue: got "
+$HIERA key fqdn=host.example.com
+
+echo ""
+echo "::osfamily=Debian"
+echo -n "expect Commonvalue: got "
+$HIERA key ::osfamily=Debian
+
+echo ""
+echo "::osfamily=RedHat"
+echo -n "expect RedHatvalue: got "
+$HIERA key ::osfamily=RedHat
+
+echo ""
+echo "::fqdn=other"
+echo -n "expect Othervalue: got "
+$HIERA key ::fqdn=other
+
+echo ""
+echo "::fqdn=host.example.com"
+echo -n "expect Commonvalue: got "
+$HIERA key ::fqdn=host.example.com


### PR DESCRIPTION
  Add a default_prof to the scope hash to create a matching no-colon-prepend key when a prepended key exists.