### PR TITLE
(maint) Fix commits checker regex

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -62,7 +62,7 @@ task(:commits) do
   %x{git log --no-merges --pretty=%s master..$HEAD}.each_line do |commit_summary|
     # This regex tests for the currently supported commit summary tokens: maint, doc, packaging, or hi-<number>.
     # The exception tries to explain it in more full.
-    if /^\(maint|doc|packaging|hi-\d+\)|revert/i.match(commit_summary).nil?
+    if /^\((maint|doc|packaging|hi-\d+)\)|revert/i.match(commit_summary).nil?
       raise "\n\n\n\tThis commit summary didn't match CONTRIBUTING.md guidelines:\n" \
         "\n\t\t#{commit_summary}\n" \
         "\tThe commit summary (i.e. the first line of the commit message) should start with one of:\n"  \


### PR DESCRIPTION
Previously the check for the trailing paren was only made
for HI-<digits> (but not for maint or doc or packaging). This fixes
that regex.