### PR TITLE
(maint) Fix running acceptance from git

### DIFF
--- a/acceptance/config/git/options.rb
+++ b/acceptance/config/git/options.rb
@@ -1,5 +1,5 @@
 {
-  :install => ['PUPPET/master', 'FACTER/master'],
+  :install => ['PUPPET/master', 'FACTER/2.x'],
   :pre_suite => [
     'setup/common/00_EnvSetup.rb',
     'setup/git/pre-suite/01_TestSetup.rb',


### PR DESCRIPTION
Facter#master and stable require compiling to run, so for now pin
acceptance from git to use Facter#2.x.