### PR TITLE
(HI-428) Add Solaris 10/11 SPARC node defs

### DIFF
--- a/acceptance/config/nodes/solaris-10-sparc
+++ b/acceptance/config/nodes/solaris-10-sparc
@@ -1,0 +1,5 @@
+HOSTS:
+  solaris-10-sparc:
+    roles:
+      - agent
+    platform: solaris-10-sparc

--- a/acceptance/config/nodes/solaris-11-sparc
+++ b/acceptance/config/nodes/solaris-11-sparc
@@ -1,0 +1,5 @@
+HOSTS:
+  solaris-11-sparc:
+    roles:
+      - agent
+    platform: solaris-11-sparc


### PR DESCRIPTION
This commit adds node definitions for solaris sparc 10 and 11
agents using the SPARC architecture.