### PR TITLE
(HI-428) Add Solaris 10/11 SPARC node defs

### DIFF
--- a/acceptance/config/nodes/solaris-10-sparc.yaml
+++ b/acceptance/config/nodes/solaris-10-sparc.yaml
@@ -1,0 +1,6 @@
+---
+HOSTS:
+  solaris-10-sparc:
+    roles:
+      - agent
+    platform: solaris-10-sparc

--- a/acceptance/config/nodes/solaris-10-x86_64.yaml
+++ b/acceptance/config/nodes/solaris-10-x86_64.yaml
@@ -1,3 +1,4 @@
+---
 HOSTS:
   agent:
     roles:

--- a/acceptance/config/nodes/solaris-11-sparc.yaml
+++ b/acceptance/config/nodes/solaris-11-sparc.yaml
@@ -1,0 +1,6 @@
+---
+HOSTS:
+  solaris-11-sparc:
+    roles:
+      - agent
+    platform: solaris-11-sparc

--- a/acceptance/config/nodes/solaris-11-x86_64.yaml
+++ b/acceptance/config/nodes/solaris-11-x86_64.yaml
@@ -1,3 +1,4 @@
+---
 HOSTS:
   agent:
     roles:


### PR DESCRIPTION
This commit adds node definitions for solaris sparc 10 and 11
agents using the SPARC architecture.