### PR TITLE
Added memcache caching method for Hiera backends

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ group :development, :test do
   gem 'mocha', "~> 0.10.5", :require => false
   gem 'json', "~> 1.7", :require => false, :platforms => :ruby
   gem "yarjuf", "~> 1.0"
-  gem 'dali', "~> 2.7.4"
+  gem 'dalli', "~> 2.7.4"
 end
 
 

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ group :development, :test do
   gem 'mocha', "~> 0.10.5", :require => false
   gem 'json', "~> 1.7", :require => false, :platforms => :ruby
   gem "yarjuf", "~> 1.0"
+  gem 'dali', "~> 2.7.4"
 end
 
 

--- a/lib/hiera.rb
+++ b/lib/hiera.rb
@@ -11,6 +11,7 @@ class Hiera
   require "hiera/noop_logger"
   require "hiera/fallback_logger"
   require "hiera/filecache"
+  require "hiera/memcache"
 
   class << self
     attr_reader :logger

--- a/lib/hiera/memcache.rb
+++ b/lib/hiera/memcache.rb
@@ -1,0 +1,26 @@
+require 'dalli'
+require 'base64'
+
+class Hiera
+  class Memcache
+    def initialize(servers)
+      @memcache ||= new_client servers
+    end
+
+    def fetch(key, ttl, &block)
+      uukey=Base64.encode64(key)
+      @memcache ? @memcache.fetch(uukey, ttl, &block) : block.call
+    end
+
+    def new_client(servers)
+      client = Dalli::Client.new(servers)
+      begin
+        client.alive!
+      rescue StandardError
+        false
+      else
+        client
+      end
+    end
+  end
+end


### PR DESCRIPTION
I found very useful to have a memcache cache (similar with Filecache class) for custom hiera backends. It seems that using memcache decreases the catalog compilation time three times in our case.
Since this is a useful feature across backends, I think that it should be put in the hiera library. That's why I'm proposing this PR.

On the other hand, the dependency on ruby Dalli class should be evaluated - no official RPM exists for RH and CentOS, only for Fedora and Ubuntu.

Several usage information:

The following code should be specified in the backend code:

in initialize method:

@cache = cache || Memcache.new(@servers)

(of course, the @servers array should be taken from the configuration file during initialization)

in lookup method:

@cache.fetch(key) { search_method(key) }

where key is the lookup key (or something obtained from lookup key) and search_method is the expensive code called for finding the information pertaining to lookup key.
