### PR TITLE
(maint) Add acceptance pre-suite to rm puppet on sparc

### DIFF
--- a/acceptance/config/aio/options.rb
+++ b/acceptance/config/aio/options.rb
@@ -1,6 +1,7 @@
 {
   :type => 'aio',
   :pre_suite => [
+    'setup/common/pre-suite/000-delete-puppet-when-sparc.rb',
     'setup/aio/pre-suite/010_Install.rb',
   ],
 }

--- a/acceptance/config/git/options.rb
+++ b/acceptance/config/git/options.rb
@@ -1,6 +1,7 @@
 {
   :install => ['PUPPET/master', 'FACTER/2.x'],
   :pre_suite => [
+    'setup/common/pre-suite/000-delete-puppet-when-sparc.rb',
     'setup/common/00_EnvSetup.rb',
     'setup/git/pre-suite/01_TestSetup.rb',
   ],

--- a/acceptance/config/packages/options.rb
+++ b/acceptance/config/packages/options.rb
@@ -1,5 +1,6 @@
 {
   :pre_suite => [
+    'setup/common/pre-suite/000-delete-puppet-when-sparc.rb',
     'setup/common/00_EnvSetup.rb',
     'setup/packages/pre-suite/010_Install.rb',
   ],

--- a/acceptance/setup/common/pre-suite/000-delete-puppet-when-sparc.rb
+++ b/acceptance/setup/common/pre-suite/000-delete-puppet-when-sparc.rb
@@ -1,0 +1,14 @@
+test_name "Expunge puppet bits if hypervisor is none"
+
+confine :to, :platform => 'sparc'
+
+# Ensure that the any previous installations of puppet
+# are removed from the host if it is not managed by a
+# provisioning hypervisor on sparc solaris.
+
+hosts.each do |host|
+  if host[:hypervisor] == "none"
+    on(host, "pkginfo | grep puppet | cut -f2 -d ' ' | xargs pkgrm -n -a noask", :acceptable_exit_codes => [0,1])
+    on(host, 'find / -name "*puppet*" -print | xargs rm -rf')
+  end
+end


### PR DESCRIPTION
This commit adds a beaker pre-suite to ensure that puppet packages
and components are removed when the platform is on sparc and the
hypervisor is none.

This ensures that the sparc testing platform does not have any
remaining puppet bits when it is not being managed by a provisioning
hypervisor.