### PR TITLE
(maint) Improve error message in read_file for filecache

### DIFF
--- a/lib/hiera/filecache.rb
+++ b/lib/hiera/filecache.rb
@@ -53,7 +53,7 @@ class Hiera
         @cache[path][:data] = block_given? ? yield(data) : data
 
         if !@cache[path][:data].is_a?(expected_type)
-          raise TypeError, "Data retrieved from #{path} is #{data.class} not #{expected_type}"
+          raise TypeError, "Data retrieved from #{path} is #{@cache[path][:data].class} not #{expected_type}"
         end
       end
 


### PR DESCRIPTION
Previously if a type error occurred during the file_read, the error
message would always say that the data retrieved is a string, and not
the expected type. This is because data comes from File.read, which
returns a string. Having the class of the data from the @cache object
allows the error message to be more helpful and return the class of the
parsed data instead of just 'String'.