### PR TITLE
(HI-473) Remove master from acceptance node defs

### DIFF
--- a/acceptance/config/nodes/osx-1010-x86_64.yaml
+++ b/acceptance/config/nodes/osx-1010-x86_64.yaml
@@ -1,11 +1,5 @@
 ---
 HOSTS:
-  master:
-    roles:
-    - master
-    platform: el-7-x86_64
-    hypervisor: vcloud
-    template: redhat-7-x86_64
   agent:
     roles:
     - agent

--- a/acceptance/config/nodes/osx-109-x86_64.yaml
+++ b/acceptance/config/nodes/osx-109-x86_64.yaml
@@ -1,11 +1,5 @@
 ---
 HOSTS:
-  master:
-    roles:
-    - master
-    platform: el-7-x86_64
-    hypervisor: vcloud
-    template: redhat-7-x86_64
   agent:
     roles:
     - agent

--- a/acceptance/config/nodes/ubuntu-1504-i386.yaml
+++ b/acceptance/config/nodes/ubuntu-1504-i386.yaml
@@ -1,11 +1,5 @@
 ---
 HOSTS:
-  master:
-    roles:
-    - master
-    platform: el-7-x86_64
-    hypervisor: vcloud
-    template: redhat-7-x86_64
   agent:
     roles:
     - agent

--- a/acceptance/config/nodes/ubuntu-1504-x86_64.yaml
+++ b/acceptance/config/nodes/ubuntu-1504-x86_64.yaml
@@ -1,11 +1,5 @@
 ---
 HOSTS:
-  master:
-    roles:
-    - master
-    platform: el-7-x86_64
-    hypervisor: vcloud
-    template: redhat-7-x86_64
   agent:
     roles:
     - agent


### PR DESCRIPTION
This commit removes master nodes from the node definitions
used for acceptance testing. Master nodes are not required
for hiera testing.