### PR TITLE
(HI-471) Allow backends to perform qualified key lookup

### DIFF
--- a/lib/hiera/backend.rb
+++ b/lib/hiera/backend.rb
@@ -263,8 +263,14 @@ class Hiera
             backend = (@backends[backend] ||= find_backend(backend_constant))
             found_in_backend = false
             new_answer = catch(:no_such_key) do
-              value = backend.lookup(segments[0], scope, order_override, resolution_type, context)
-              value = qualified_lookup(subsegments, value) unless subsegments.nil?
+              if subsegments.nil? 
+                value = backend.lookup(key, scope, order_override, resolution_type, context)
+              elsif backend.respond_to?(:lookup_with_segments)
+                value = backend.lookup_with_segments(segments, scope, order_override, resolution_type, context)
+              else
+                value = backend.lookup(segments[0], scope, order_override, resolution_type, context)
+                value = qualified_lookup(subsegments, value) unless subsegments.nil?
+              end
               found_in_backend = true
               value
             end


### PR DESCRIPTION
Previously, Hiera performed qualified key lookup by asking the backend for the
top-level key and descending into the data.  As an optimization, provide the
fully qualified key to the backend so that it can minimize processing required
to return a large data structure when only a small portion of it is used.  This
can speed up lookups for backends where processing data is expensive (like
eyaml).