### PR TITLE
(HI-443) Update platform field to use version numbers

### DIFF
--- a/acceptance/config/nodes/osx-1010-x86_64.yaml
+++ b/acceptance/config/nodes/osx-1010-x86_64.yaml
@@ -3,7 +3,7 @@ HOSTS:
   agent:
     roles:
     - agent
-    platform: osx-yosemite-x86_64
+    platform: osx-10.10-x86_64
     hypervisor: vcloud
     template: osx-1010-x86_64
 CONFIG:

--- a/acceptance/config/nodes/osx-1011-x86_64.yaml
+++ b/acceptance/config/nodes/osx-1011-x86_64.yaml
@@ -3,7 +3,7 @@ HOSTS:
   agent:
     roles:
     - agent
-    platform: osx-elcapitan-x86_64
+    platform: osx-10.11-x86_64
     hypervisor: vcloud
     template: osx-1011-x86_64
 CONFIG:

--- a/acceptance/config/nodes/osx-109-x86_64.yaml
+++ b/acceptance/config/nodes/osx-109-x86_64.yaml
@@ -3,7 +3,7 @@ HOSTS:
   agent:
     roles:
     - agent
-    platform: osx-mavericks-x86_64
+    platform: osx-10.9-x86_64
     hypervisor: vcloud
     template: osx-109-x86_64
 CONFIG:

--- a/acceptance/lib/puppet/acceptance/install_utils.rb
+++ b/acceptance/lib/puppet/acceptance/install_utils.rb
@@ -7,7 +7,7 @@ module Puppet
   module Acceptance
     module InstallUtils
       PLATFORM_PATTERNS = {
-        :redhat        => /fedora|el|centos/,
+        :redhat        => /fedora|el-|centos/,
         :debian        => /debian|ubuntu/,
         :debian_ruby18 => /debian|ubuntu-lucid|ubuntu-precise/,
         :solaris       => /solaris/,


### PR DESCRIPTION
Previously, beaker tried to install puppet-agent on OSX 10.11 twice
because the 'el' regex matched the elcapitan platform. When the 'el'
regex was made to be more specific, beaker added PermitUserEnvironment
to the pre 10.11 location, because beaker expects platform to contain
version numbers, not codenames.

This commit changes all OSX host configs to version numbers as
codenames, and makes the 'el' regex more specific, as 'el' could occur
in a future OS name.