### PR TITLE
Added compatibility mode option for deep and deeper merge behavior

### DIFF
--- a/lib/hiera/backend.rb
+++ b/lib/hiera/backend.rb
@@ -183,13 +183,16 @@ class Hiera
       # Merges two hashes answers with the given or configured merge behavior. Behavior can be given
       # by passing _resolution_type_ as a Hash
       #
-      #  :merge_behavior: {:native|:deep|:deeper}
+      #  :merge_behavior: {:native|:deep|:deeper|:deep_compat|:deeper_compat}
       #
       # Deep merge options use the Hash utility function provided by [deep_merge](https://github.com/danielsdeleo/deep_merge)
+      # If you also include active support you need a compatibility mode from [deep_merge](https://github.com/danielsdeleo/deep_merge#using-deep_merge-in-rails)
       #
-      #  :native => Native Hash.merge
-      #  :deep   => Use Hash.deep_merge
-      #  :deeper => Use Hash.deep_merge!
+      #  :native        => Native Hash.merge
+      #  :deep          => Use Hash.deep_merge
+      #  :deeper        => Use Hash.deep_merge!
+      #  :deep_compat   => Use Hash.deeper_merge
+      #  :deeper_compat => Use Hash.deeper_merge!
       #
       # @param left [Hash] left side of the merge
       # @param right [Hash] right side of the merge
@@ -207,6 +210,10 @@ class Hiera
           end
 
         case behavior
+        when :deeper_compat,'deeper_compat'
+          left.deeper_merge!(right, options)
+        when :deep_compat,'deep_compat'
+          left.deeper_merge(right, options)
         when :deeper,'deeper'
           left.deep_merge!(right, options)
         when :deep,'deep'

--- a/spec/unit/backend_spec.rb
+++ b/spec/unit/backend_spec.rb
@@ -723,6 +723,18 @@ class Hiera
         expect(Backend.merge_answer({"a" => "answer"},{"b" => "bnswer"})).to eq({"a" => "answer", "b" => "bnswer"})
       end
 
+      it "uses deeper_merge! when configured with :merge_behavior => :deeper_compat" do
+        Config.load({:merge_behavior => :deeper_compat})
+        Hash.any_instance.expects('deeper_merge!').with({"b" => "bnswer"}, {}).returns({"a" => "answer", "b" => "bnswer"})
+        expect(Backend.merge_answer({"a" => "answer"},{"b" => "bnswer"})).to eq({"a" => "answer", "b" => "bnswer"})
+      end
+
+      it "uses deeper_merge when configured with :merge_behavior => :deep_compat" do
+        Config.load({:merge_behavior => :deep_compat})
+        Hash.any_instance.expects('deeper_merge').with({"b" => "bnswer"}, {}).returns({"a" => "answer", "b" => "bnswer"})
+        expect(Backend.merge_answer({"a" => "answer"},{"b" => "bnswer"})).to eq({"a" => "answer", "b" => "bnswer"})
+      end
+
       it "disregards configuration when 'merge' parameter is given as a Hash" do
         Config.load({:merge_behavior => :deep})
         Hash.any_instance.expects('deep_merge!').with({"b" => "bnswer"}, {}).returns({"a" => "answer", "b" => "bnswer"})


### PR DESCRIPTION
We just created a project that uses hiera and active record. Active support is included automatically and also provides deep_merge. This deep merge does not allow additional options and is in that way not compatible. The deep_merge gem has a compatiblity mode for this, see https://github.com/danielsdeleo/deep_merge#using-deep_merge-in-rails

This commit adds the possibility to use the compatibility mode.
