### PR TITLE
(HI-483) Use compaitibility mode from deep_merge as default

### DIFF
--- a/lib/hiera/backend.rb
+++ b/lib/hiera/backend.rb
@@ -2,7 +2,7 @@ require 'hiera/util'
 require 'hiera/interpolate'
 
 begin
-  require 'deep_merge'
+  require 'deep_merge/rails_compat'
 rescue LoadError
 end
 
@@ -186,10 +186,11 @@ class Hiera
       #  :merge_behavior: {:native|:deep|:deeper}
       #
       # Deep merge options use the Hash utility function provided by [deep_merge](https://github.com/danielsdeleo/deep_merge)
+      # It uses the compatibility mode [deep_merge](https://github.com/danielsdeleo/deep_merge#using-deep_merge-in-rails)
       #
       #  :native => Native Hash.merge
-      #  :deep   => Use Hash.deep_merge
-      #  :deeper => Use Hash.deep_merge!
+      #  :deep   => Use Hash.deeper_merge
+      #  :deeper => Use Hash.deeper_merge!
       #
       # @param left [Hash] left side of the merge
       # @param right [Hash] right side of the merge
@@ -208,9 +209,9 @@ class Hiera
 
         case behavior
         when :deeper,'deeper'
-          left.deep_merge!(right, options)
+          left.deeper_merge!(right, options)
         when :deep,'deep'
-          left.deep_merge(right, options)
+          left.deeper_merge(right, options)
         else # Native and undefined
           left.merge(right)
         end

--- a/lib/hiera/config.rb
+++ b/lib/hiera/config.rb
@@ -53,6 +53,7 @@ class Hiera::Config
       when :deep,'deep',:deeper,'deeper'
         begin
           require "deep_merge"
+          require "deep_merge/rails_compat"
         rescue LoadError
           raise Hiera::Error, "Must have 'deep_merge' gem installed for the configured merge_behavior."
         end

--- a/spec/unit/backend_spec.rb
+++ b/spec/unit/backend_spec.rb
@@ -713,30 +713,30 @@ class Hiera
 
       it "uses deep_merge! when configured with :merge_behavior => :deeper" do
         Config.load({:merge_behavior => :deeper})
-        Hash.any_instance.expects('deep_merge!').with({"b" => "bnswer"}, {}).returns({"a" => "answer", "b" => "bnswer"})
+        Hash.any_instance.expects('deeper_merge!').with({"b" => "bnswer"}, {}).returns({"a" => "answer", "b" => "bnswer"})
         expect(Backend.merge_answer({"a" => "answer"},{"b" => "bnswer"})).to eq({"a" => "answer", "b" => "bnswer"})
       end
 
       it "uses deep_merge when configured with :merge_behavior => :deep" do
         Config.load({:merge_behavior => :deep})
-        Hash.any_instance.expects('deep_merge').with({"b" => "bnswer"}, {}).returns({"a" => "answer", "b" => "bnswer"})
+        Hash.any_instance.expects('deeper_merge').with({"b" => "bnswer"}, {}).returns({"a" => "answer", "b" => "bnswer"})
         expect(Backend.merge_answer({"a" => "answer"},{"b" => "bnswer"})).to eq({"a" => "answer", "b" => "bnswer"})
       end
 
       it "disregards configuration when 'merge' parameter is given as a Hash" do
         Config.load({:merge_behavior => :deep})
-        Hash.any_instance.expects('deep_merge!').with({"b" => "bnswer"}, {}).returns({"a" => "answer", "b" => "bnswer"})
+        Hash.any_instance.expects('deeper_merge!').with({"b" => "bnswer"}, {}).returns({"a" => "answer", "b" => "bnswer"})
         expect(Backend.merge_answer({"a" => "answer"},{"b" => "bnswer"}, {:behavior => 'deeper' })).to eq({"a" => "answer", "b" => "bnswer"})
       end
 
       it "propagates deep merge options when given Hash 'merge' parameter" do
-        Hash.any_instance.expects('deep_merge!').with({"b" => "bnswer"}, { :knockout_prefix => '-' }).returns({"a" => "answer", "b" => "bnswer"})
+        Hash.any_instance.expects('deeper_merge!').with({"b" => "bnswer"}, { :knockout_prefix => '-' }).returns({"a" => "answer", "b" => "bnswer"})
         expect(Backend.merge_answer({"a" => "answer"},{"b" => "bnswer"}, {:behavior => 'deeper', :knockout_prefix => '-'})).to eq({"a" => "answer", "b" => "bnswer"})
       end
 
       it "passes Config[:deep_merge_options] into calls to deep_merge" do
         Config.load({:merge_behavior => :deep, :deep_merge_options => { :knockout_prefix => '-' } })
-        Hash.any_instance.expects('deep_merge').with({"b" => "bnswer"}, {:knockout_prefix => '-'}).returns({"a" => "answer", "b" => "bnswer"})
+        Hash.any_instance.expects('deeper_merge').with({"b" => "bnswer"}, {:knockout_prefix => '-'}).returns({"a" => "answer", "b" => "bnswer"})
         expect(Backend.merge_answer({"a" => "answer"},{"b" => "bnswer"})).to eq({"a" => "answer", "b" => "bnswer"})
       end
     end


### PR DESCRIPTION
With this commit you can use hiera and active support in the same project.

See discussion in previous pull request https://github.com/puppetlabs/hiera/pull/324