### PR TITLE
(HI-220) Deprecate use of interpolation methods in Hiera config

### DIFF
--- a/lib/hiera/backend.rb
+++ b/lib/hiera/backend.rb
@@ -41,8 +41,7 @@ class Hiera
           raise(Hiera::InvalidConfigurationError,
                 "datadir for #{backend} cannot be an array")
         end
-
-        parse_string(dir, scope)
+        Hiera::Interpolate.interpolate_config(dir, scope, nil)
       end
 
       # Finds the path to a datafile based on the Backend#datadir
@@ -88,7 +87,7 @@ class Hiera
         hierarchy.insert(0, override) if override
 
         hierarchy.flatten.map do |source|
-          source = parse_string(source, scope, {}, :order_override => override)
+          source = Hiera::Interpolate.interpolate_config(source, scope, :order_override => override)
           yield(source) unless source == "" or source =~ /(^\/|\/\/|\/$)/
         end
       end

--- a/spec/unit/backend_spec.rb
+++ b/spec/unit/backend_spec.rb
@@ -92,8 +92,8 @@ class Hiera
       end
 
       it "parses the names of the hierarchy levels using the given scope" do
-        Backend.expects(:parse_string).with('nodes/%{::trusted.certname}', {:rspec => :tests}, {}, {:order_override => nil})
-        Backend.expects(:parse_string).with('common', {:rspec => :tests}, {}, {:order_override => nil})
+        Hiera::Interpolate.expects(:interpolate_config).with('nodes/%{::trusted.certname}', {:rspec => :tests}, {:order_override => nil})
+        Hiera::Interpolate.expects(:interpolate_config).with('common', {:rspec => :tests}, {:order_override => nil})
         Backend.datasources({:rspec => :tests}) { }
       end
 

--- a/spec/unit/fixtures/interpolate/config/hiera_iplm_hiera.yaml
+++ b/spec/unit/fixtures/interpolate/config/hiera_iplm_hiera.yaml
@@ -1,0 +1,5 @@
+:backends:
+  - yaml
+
+:hierarchy:
+  - "%{hiera('role')}"

--- a/spec/unit/fixtures/interpolate/config/hiera_iplm_other.yaml
+++ b/spec/unit/fixtures/interpolate/config/hiera_iplm_other.yaml
@@ -1,0 +1,5 @@
+:backends:
+  - yaml
+
+:hierarchy:
+  - "%{scope('osfamily')}"

--- a/spec/unit/interpolate_spec.rb
+++ b/spec/unit/interpolate_spec.rb
@@ -33,4 +33,19 @@ describe "Hiera" do
       expect(hiera.lookup('foo', nil, {}, 'alternate')).to eq('alternate')
     end
   end
+
+  context 'when doing interpolation in config file' do
+    let(:fixtures) { File.join(HieraSpec::FIXTURE_DIR, 'interpolate') }
+
+    it 'should not permit interpolation method "hiera"' do
+      hiera = Hiera.new(:config => File.join(fixtures, 'config', 'hiera_iplm_hiera.yaml'))
+      expect{ hiera.lookup('foo', nil, {}) }.to raise_error(Hiera::InterpolationInvalidValue, "Cannot use interpolation method 'hiera' in hiera configuration file")
+    end
+
+    it 'should issue warning when interpolation methods are used' do
+      hiera = Hiera.new(:config => File.join(fixtures, 'config', 'hiera_iplm_other.yaml'))
+      Hiera.expects(:warn).with('Use of interpolation methods in hiera configuration file is deprecated').at_least_once
+      hiera.lookup('foo', nil, {})
+    end
+  end
 end


### PR DESCRIPTION
Using interpolation methods in the hiera configuration configuration
file should be avoided. The 'hiera' method in particular will lead
to problems since it's very likely that it will cause an endless
recursion when a new attempt is made to read the configuration file.

This commit ensures that a deprecation warning is issued when the
interpolation method syntax is used in a hiera configuration file. An
error will be raised in case the 'hiera' interpolation method is used.