### PR TITLE
(HI-486) Allow host configs to be generated at runtime

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -11,6 +11,7 @@ def location_for(place, fake_version = nil)
 end
 
 gem "beaker", *location_for(ENV['BEAKER_VERSION'] || "~> 2.27")
+gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 0.2")
 gem 'rake', "~> 10.1.0"
 
 if File.exists? "#{__FILE__}.local"

--- a/acceptance/Rakefile
+++ b/acceptance/Rakefile
@@ -1,6 +1,9 @@
 require 'rake/clean'
 require 'pp'
 require 'yaml'
+require 'securerandom'
+require 'beaker-hostgenerator'
+
 $LOAD_PATH << File.expand_path(File.join(File.dirname(__FILE__), 'lib'))
 require 'puppet/acceptance/git_utils'
 extend Puppet::Acceptance::GitUtils
@@ -90,7 +93,17 @@ EOS
   tests = ENV['TESTS'] || ENV['TEST']
   tests_opt = "--tests=#{tests}" if tests
 
-  config_opt = "--hosts=#{config}" if config
+  platforms = ENV['PLATFORMS']
+  if platforms
+    cli = BeakerHostGenerator::CLI.new([platforms, '--disable-default-role'])
+    ENV['CONFIG'] = "tmp/#{platforms}-#{SecureRandom.uuid}.yaml"
+    File.open(config, 'w') do |fh|
+      fh.print(cli.execute)
+    end
+    config_opt = "--hosts=#{config}"
+  elsif config
+    config_opt = "--hosts=#{config}"
+  end
 
   overriding_options = ENV['OPTIONS']
 
@@ -260,7 +273,8 @@ namespace :ci do
 
     USAGE = <<-EOS
 Requires commit SHA to be put under test as environment variable: SHA='<sha>'.
-Also must set CONFIG=config/nodes/foo.yaml or include it in an options.rb for Beaker.
+Also must set CONFIG=config/nodes/foo.yaml or include it in an options.rb for Beaker,
+or specify PLATFORMS in a form beaker-hostgenerator can consume, e.g. redhat7-64m-debian6-64a.
 You may set TESTS=path/to/test,and/more/tests.
 You may set additional Beaker OPTIONS='--more --options'
 If testing from git checkouts, you may optionally set the github fork to checkout from using FORK='other-puppet-fork'.


### PR DESCRIPTION
This commit adds a dependency on beaker-hostgenerator in the
acceptance Gemfile, which may be overridden using the
`BEAKER_HOSTGENERATOR_VERSION` environment variable.

The acceptance Rakefile will continue to use the `CONFIG` environment
variable, which points to an existing host config file. If `CONFIG` is
not specified, but `PLATFORMS` is, then the Rakefile will use
beaker-hostgenerator to dynamically generate a host config. The host
config is generated in the `hiera/acceptance/tmp` directory, as
opposed to `/tmp` so that it doesn't conflict with concurrent
acceptance tests running on the same CI coordinator. It also appends
SecureRandom to the hostfile, because it seems like a good idea. The
resulting host config is copied to the `log/latest/config.yml`.

For example, to run against a tagged build:

    $ bundle exec rake ci:test:aio PLATFORMS=redhat7-64a SHA=1.3.2

To run against a non-tagged commit:

    $ bundle exec rake ci:test:aio PLATFORMS=redhat7-64a \
      SHA=<full sha> SUITE_VERSION=<git describe>

This commit doesn't remove the static host configs as CI jobs need
to be updated first.