### PR TITLE
(HI-486) Bump to beaker-hostgenerator 0.3.1

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -11,7 +11,7 @@ def location_for(place, fake_version = nil)
 end
 
 gem "beaker", *location_for(ENV['BEAKER_VERSION'] || "~> 2.27")
-gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 0.3.1")
+gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 0.3")
 gem 'rake', "~> 10.1.0"
 
 if File.exists? "#{__FILE__}.local"

--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -11,7 +11,7 @@ def location_for(place, fake_version = nil)
 end
 
 gem "beaker", *location_for(ENV['BEAKER_VERSION'] || "~> 2.27")
-gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 0.2")
+gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 0.3.1")
 gem 'rake', "~> 10.1.0"
 
 if File.exists? "#{__FILE__}.local"

--- a/acceptance/Rakefile
+++ b/acceptance/Rakefile
@@ -100,7 +100,7 @@ EOS
   # conditional (and this comment) once that pipeline change is made.
   target = ENV['TEST_TARGET'] if ENV['TEST_TARGET'] && ENV['TEST_TARGET'][-1,1] == 'a'
   if target
-    cli = BeakerHostGenerator::CLI.new([target, '--disable-default-role'])
+    cli = BeakerHostGenerator::CLI.new([target, '--disable-default-role', '--osinfo-version', '1'])
     ENV['CONFIG'] = "tmp/#{target}-#{SecureRandom.uuid}.yaml"
     FileUtils.mkdir_p('tmp')
     File.open(config, 'w') do |fh|


### PR DESCRIPTION
The puppet-agent components need the osinfo version 1 of b-hg,
so that centos4 is correctly specified as a platform name, so
that puppet-agent can be installed on centos4.

This commit moves to b-hg 0.3.1, the first version implementing
that, and specifies the osinfo version when invoking b-hg.