### PR TITLE
(maint) Acceptance Rake - give CONFIG priority

### DIFF
--- a/acceptance/Rakefile
+++ b/acceptance/Rakefile
@@ -95,15 +95,15 @@ EOS
   tests_opt = "--tests=#{tests}" if tests
 
   target = ENV['TEST_TARGET']
-  if target
+  if config and File.exists?(config)
+    config_opt = "--hosts=#{config}"
+  elsif target
     cli = BeakerHostGenerator::CLI.new([target, '--disable-default-role', '--osinfo-version', '1'])
-    ENV['CONFIG'] = "tmp/#{target}-#{SecureRandom.uuid}.yaml"
+    ENV['BEAKER_HOSTS'] = "tmp/#{target}-#{SecureRandom.uuid}.yaml"
     FileUtils.mkdir_p('tmp')
     File.open(config, 'w') do |fh|
       fh.print(cli.execute)
     end
-    config_opt = "--hosts=#{config}"
-  elsif config
     config_opt = "--hosts=#{config}"
   end
 
@@ -244,7 +244,7 @@ def sha
 end
 
 def config
-  ENV['CONFIG']
+  ENV['BEAKER_HOSTS']
 end
 
 namespace :ci do
@@ -254,7 +254,7 @@ namespace :ci do
       sh("beaker",
           "--type", "git",
           "--load-path", "lib",
-          "--hosts", ENV['CONFIG'],
+          "--hosts", ENV['BEAKER_HOSTS'],
           "--pre-suite", "setup/git",
           "--install", "PUPPET/#{ENV['PUPPET'] || 'master'},FACTER/#{ENV['FACTER'] || 'master'},HIERA/#{ENV['HIERA'] || 'master'}",
           "--tests", "tests",
@@ -275,7 +275,7 @@ namespace :ci do
 
     USAGE = <<-EOS
 Requires commit SHA to be put under test as environment variable: SHA='<sha>'.
-Also must set CONFIG=config/nodes/foo.yaml or include it in an options.rb for Beaker,
+Also must set BEAKER_HOSTS=config/nodes/foo.yaml or include it in an options.rb for Beaker,
 or specify TEST_TARGET in a form beaker-hostgenerator accepts, e.g. ubuntu1504-64a.
 You may set TESTS=path/to/test,and/more/tests.
 You may set additional Beaker OPTIONS='--more --options'


### PR DESCRIPTION
This commit changes the logic in the beaker_test rake task for
acceptance giving BEAKER_HOSTCONFIG priority over TEST_TARGET.
It also changes the name of the ENV variable from CONFIG to
BEAKER_HOSTCONFIG

In the case that a static beaker host config file is needed for
running acceptance testing, the file path to this config should
be assigned to the ENV variable BEAKER_HOSTCONFIG. This value
will take precedence over any value set for TEST_TARGET.

TEST_TARGET is still used to supply a string for dynamically
generating beaker host configs.

skip:ci