### PR TITLE
(HI-943) Update hiera.bat to current standard

### DIFF
--- a/install.rb
+++ b/install.rb
@@ -255,10 +255,13 @@ def install_binfile(from, op_file, target)
       tmp_file2 = Tempfile.new('hiera-wrapper')
       cwv = <<-EOS
 @echo off
-setlocal
-set RUBY_BIN=%~dp0
-set RUBY_BIN=%RUBY_BIN:\\=/%
-"%RUBY_BIN%ruby.exe" -x "%RUBY_BIN%hiera" %*
+SETLOCAL
+if exist "%~dp0environment.bat" (
+  call "%~dp0environment.bat" %0 %*
+) else (
+  SET "PATH=%~dp0;%PATH%"
+)
+ruby.exe -S -- hiera %*
 EOS
       File.open(tmp_file2.path, "w") { |cw| cw.puts cwv }
       install(tmp_file2.path, File.join(target, "#{op_file}.bat"), :mode => 0755, :preserve => true, :verbose => true)


### PR DESCRIPTION
With the switch over to building puppet-agent for windows with Vanagon,
we need to effectively install hiera with install.rb. This script
installs hiera.bat, which is a wrapper that lets windows handle ruby
scripts. This commit updates hiera.bat to use our environment.bat file if
we install it, and to be more in line with the hiera.bat file installed
with the puppet-agent package as built by puppet_for_the_win

This takes advantage of `environment.bat` in puppet-agent installed with https://github.com/puppetlabs/puppet-agent/pull/512