### PR TITLE
(HI-494) Bring back support for empty interpolation

### DIFF
--- a/lib/hiera/interpolate.rb
+++ b/lib/hiera/interpolate.rb
@@ -46,7 +46,7 @@ class Hiera::Interpolate
         interpolation_variable = match[1]
 
         # HI-494
-        case interpolation_variable.gsub(/\s+/, '')
+        case interpolation_variable.strip
         when '', '::'
           return ''
         end

--- a/lib/hiera/interpolate.rb
+++ b/lib/hiera/interpolate.rb
@@ -44,6 +44,13 @@ class Hiera::Interpolate
     def do_interpolation(data, scope, extra_data, context)
       if data.is_a?(String) && (match = data.match(INTERPOLATION))
         interpolation_variable = match[1]
+
+        # HI-494
+        case interpolation_variable.gsub(/\s+/, '')
+        when '', '::'
+          return ''
+        end
+
         context[:recurse_guard].check(interpolation_variable) do
           interpolate_method, key = get_interpolation_method_and_key(data)
           interpolated_data = send(interpolate_method, data, key, scope, extra_data, context)

--- a/spec/unit/fixtures/interpolate/config/hiera.yaml
+++ b/spec/unit/fixtures/interpolate/config/hiera.yaml
@@ -4,3 +4,4 @@
 :hierarchy:
   - recursive
   - niltest
+  - empty_%{}inter%{::}polation

--- a/spec/unit/fixtures/interpolate/data/empty_interpolation.yaml
+++ b/spec/unit/fixtures/interpolate/data/empty_interpolation.yaml
@@ -1,0 +1,6 @@
+empty_interpolation: 'clown%{}shoe'
+escaped_empty_interpolation: 'clown%%{}{shoe}s'
+only_empty_interpolation: '%{}'
+empty_namespace: '%{::}'
+whitespace1: '%{ :: }'
+whitespace2: '%{   }'

--- a/spec/unit/interpolate_spec.rb
+++ b/spec/unit/interpolate_spec.rb
@@ -24,6 +24,46 @@ describe "Hiera" do
     end
   end
 
+  context "when there are empty interpolations %{} in data" do
+    let(:fixtures) { File.join(HieraSpec::FIXTURE_DIR, 'interpolate') }
+
+    it 'should should produce an empty string for the interpolation' do
+      Hiera::Util.expects(:var_dir).at_least_once.returns(File.join(fixtures, 'data'))
+      hiera = Hiera.new(:config => File.join(fixtures, 'config', 'hiera.yaml'))
+      expect(hiera.lookup('empty_interpolation', nil, {})).to eq('clownshoe')
+    end
+
+    it 'the empty interpolation can be escaped' do
+      Hiera::Util.expects(:var_dir).at_least_once.returns(File.join(fixtures, 'data'))
+      hiera = Hiera.new(:config => File.join(fixtures, 'config', 'hiera.yaml'))
+      expect(hiera.lookup('escaped_empty_interpolation', nil, {})).to eq('clown%{shoe}s')
+    end
+
+    it 'the value can consist of only an empty escape' do
+      Hiera::Util.expects(:var_dir).at_least_once.returns(File.join(fixtures, 'data'))
+      hiera = Hiera.new(:config => File.join(fixtures, 'config', 'hiera.yaml'))
+      expect(hiera.lookup('only_empty_interpolation', nil, {})).to eq('')
+    end
+
+    it 'the value can consist of an empty namespace %{::}' do
+      Hiera::Util.expects(:var_dir).at_least_once.returns(File.join(fixtures, 'data'))
+      hiera = Hiera.new(:config => File.join(fixtures, 'config', 'hiera.yaml'))
+      expect(hiera.lookup('empty_namespace', nil, {})).to eq('')
+    end
+
+    it 'the value can consist of whitespace %{ :: }' do
+      Hiera::Util.expects(:var_dir).at_least_once.returns(File.join(fixtures, 'data'))
+      hiera = Hiera.new(:config => File.join(fixtures, 'config', 'hiera.yaml'))
+      expect(hiera.lookup('whitespace1', nil, {})).to eq('')
+    end
+
+    it 'the value can consist of whitespace %{  }' do
+      Hiera::Util.expects(:var_dir).at_least_once.returns(File.join(fixtures, 'data'))
+      hiera = Hiera.new(:config => File.join(fixtures, 'config', 'hiera.yaml'))
+      expect(hiera.lookup('whitespace2', nil, {})).to eq('')
+    end
+  end
+
   context "when doing interpolation with override" do
     let(:fixtures) { File.join(HieraSpec::FIXTURE_DIR, 'override') }
 


### PR DESCRIPTION
Before this, we started doing something wrong in the hiera 3.x series as
interpolation of empty strings 

See commit for details.