### PR TITLE
(maint) Fix erroneous use of .value in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ require 'hiera'
 require 'puppet'
 
 # load the facts for example.com
-scope = YAML.load_file("/opt/puppetlabs/puppet/cache/yaml/facts/example.com.yaml").values
+scope = YAML.load_file("/opt/puppetlabs/puppet/cache/yaml/facts/example.com.yaml")
 
 # create a new instance based on config file
 hiera = Hiera.new(:config => "/etc/puppetlabs/code/hiera.yaml")


### PR DESCRIPTION
Calling `.values` on the loaded facts scope breaks the example. Not sure
why that's there.