### PR TITLE
(HI-499) Fail if backend cannot be loaded

### DIFF
--- a/lib/hiera/config.rb
+++ b/lib/hiera/config.rb
@@ -74,7 +74,7 @@ class Hiera::Config
         begin
           require "hiera/backend/#{backend.downcase}_backend"
         rescue LoadError => e
-          Hiera.warn "Cannot load backend #{backend}: #{e}"
+          fail "Cannot load backend #{backend}: #{e}"
         end
       end
     end

--- a/spec/unit/backend_spec.rb
+++ b/spec/unit/backend_spec.rb
@@ -11,6 +11,15 @@ class Hiera
   end
 
   describe Backend do
+    describe "loading non existing backend" do
+      it "fails if a backend cannot be loaded" do
+        Config.load({:datadir => "/tmp/%{interpolate}", :backends => ['bogus']})
+        expect do
+          Config.load_backends
+        end.to raise_error(/Cannot load backend bogus/)
+      end
+    end
+
     describe "#datadir" do
       it "interpolates any values in the configured value" do
         Config.load({:rspec => {:datadir => "/tmp/%{interpolate}"}})


### PR DESCRIPTION
Before this, if a backend could not be loaded, this was only logged as a
warning and hiera merrily continued by serving data from remaining (if
any) backends.

This can lead to catastrophic results as lookups may be resolved with
large portions of the data missing. This in turn can cause catalogs to
contain a radically different configuration causing a wide range of
unpleasant surprises.