### PR TITLE
(HI-480) Check for escaped period when determining hash segments

### DIFF
--- a/lib/hiera/backend.rb
+++ b/lib/hiera/backend.rb
@@ -250,11 +250,13 @@ class Hiera
 
         strategy = resolution_type.is_a?(Hash) ? :hash : resolution_type
 
-        segments = key.split('.')
+        segments = key.split(/(?<!\\)\./)
         subsegments = nil
         if segments.size > 1
           raise ArgumentError, "Resolution type :#{strategy} is illegal when doing segmented key lookups" unless strategy.nil? || strategy == :priority
           subsegments = segments.drop(1)
+        else
+          key = key.gsub(/\\\./, '.')
         end
 
         found = false


### PR DESCRIPTION
Likely not the ideal way to solve this problem, but the original code is a bit overzealous with its split.

Performs backward regex lookup to determine if the period has been escaped, then removes escaping.