### PR TITLE
(HI-508) Prevent that subkeys can do lookups in string values

### DIFF
--- a/lib/hiera/backend.rb
+++ b/lib/hiera/backend.rb
@@ -314,7 +314,9 @@ class Hiera
             raise Exception, "Hiera type mismatch: Got #{value.class.name} when Array was expected enable lookup using key '#{segment}'" unless value.instance_of?(Array)
             throw :no_such_key unless segment < value.size
           else
-            raise Exception, "Hiera type mismatch: Got #{value.class.name} when a non Array object that responds to '[]' was expected to enable lookup using key '#{segment}'" unless value.respond_to?(:'[]') && !value.instance_of?(Array);
+            unless value.respond_to?(:'[]') && !(value.instance_of?(Array) || value.instance_of?(String))
+              raise Exception, "Hiera type mismatch: Got #{value.class.name} when a hash-like object was expected to enable lookup using key '#{segment}'"
+            end
             throw :no_such_key unless value.include?(segment)
           end
           value = value[segment]

--- a/spec/unit/fixtures/interpolate/data/dotted_keys.yaml
+++ b/spec/unit/fixtures/interpolate/data/dotted_keys.yaml
@@ -38,3 +38,6 @@ a.f.hiera: 'a dot f: %{hiera("''a.d''")}'
 x.1: '(hiera) x dot 1'
 x.2.scope: "x dot 2: %{'x.1'}"
 x.2.hiera: 'x dot 2: %{hiera("''x.1''")}'
+
+key: subkey
+ipl_key: '- %{hiera("key.subkey")} -'

--- a/spec/unit/interpolate_spec.rb
+++ b/spec/unit/interpolate_spec.rb
@@ -163,6 +163,14 @@ describe "Hiera" do
     it 'should not find a subkey when the dotted key is quoted with method hiera' do
       expect(hiera.lookup('"a.f.hiera"', nil, {'a' => { 'f' => '(scope) a dot f is a hash entry'}})).to eq('a dot f: ')
     end
+
+    it 'should not find a subkey that is matched within a string' do
+      expect{ hiera.lookup('ipl_key', nil, {}) }.to raise_error(/Got String when a hash-like object was expected to enable lookup using key 'subkey'/)
+    end
+
+    it 'should not find a subkey that is matched within a string' do
+      expect{ hiera.lookup('key.subkey', nil, {}) }.to raise_error(/Got String when a hash-like object was expected to enable lookup using key 'subkey'/)
+    end
   end
 
   context 'when bad interpolation expressions are encountered' do


### PR DESCRIPTION
Before this commit, a subkey of a dotted key could be matched by a
string that contained a matching text. Hiera would require that the
value
responded to :[] and that it was not an Array (arrays should use numeric
index). A string fulfills that requirement.

This commit adds the constraint that the value cannot be a String when
subjected to a lookup.