### PR TITLE
(HI-502) Improve error reporting when using dotted keys.

### DIFF
--- a/lib/hiera/interpolate.rb
+++ b/lib/hiera/interpolate.rb
@@ -98,8 +98,8 @@ class Hiera::Interpolate
 
     def scope_interpolate(data, key, scope, extra_data, context)
       segments = Hiera::Util.split_key(key) { |problem| Hiera::InterpolationInvalidValue.new("#{problem} in interpolation expression: #{data}") }
-      catch(:no_such_key) { return Hiera::Backend.qualified_lookup(segments, scope) }
-      catch(:no_such_key) { Hiera::Backend.qualified_lookup(segments, extra_data) }
+      catch(:no_such_key) { return Hiera::Backend.qualified_lookup(segments, scope, key) }
+      catch(:no_such_key) { Hiera::Backend.qualified_lookup(segments, extra_data, key) }
     end
     private :scope_interpolate
 

--- a/spec/unit/backend_spec.rb
+++ b/spec/unit/backend_spec.rb
@@ -682,6 +682,34 @@ class Hiera
         expect(Backend.lookup('key.33', 'dflt', {}, nil, nil)).to eq('dflt')
       end
 
+      it 'will fail when dotted key access is made using a numeric index and value is not array' do
+        Config.load({:yaml => {:datadir => '/tmp'}})
+        Config.load_backends
+        Backend::Yaml_backend.any_instance.expects(:lookup).with('key', {}, nil, nil, instance_of(Hash)).returns(
+          {'one' => 'value 1', 'two' => 'value 2'})
+        expect {Backend.lookup('key.33', 'dflt', {}, nil, nil)}.to raise_error(Exception,
+          /Got Hash when Array was expected to access value using '33' from key 'key.33'/)
+      end
+
+      it 'will fail when dotted key access is made using a string and value is not hash' do
+        Config.load({:yaml => {:datadir => '/tmp'}})
+        Config.load_backends
+        Backend::Yaml_backend.any_instance.expects(:lookup).with('key', {}, nil, nil, instance_of(Hash)).returns(
+          ['value 1', 'value 2'])
+        expect {Backend.lookup('key.one', 'dflt', {}, nil, nil)}.to raise_error(Exception,
+          /Got Array when a hash-like object was expected to access value using 'one' from key 'key.one'/)
+      end
+
+      it 'will fail when dotted key access is made using resolution type :hash' do
+        expect {Backend.lookup('key.one', 'dflt', {}, nil, :hash)}.to raise_error(Exception,
+          /Resolution type :hash is illegal when accessing values using dotted keys. Offending key was 'key.one'/)
+      end
+
+      it 'will fail when dotted key access is made using resolution type :array' do
+        expect {Backend.lookup('key.one', 'dflt', {}, nil, :array)}.to raise_error(Exception,
+          /Resolution type :array is illegal when accessing values using dotted keys. Offending key was 'key.one'/)
+      end
+
       it 'can use qualified key in interpolation to lookup value in hash' do
         Config.load({:yaml => {:datadir => '/tmp'}})
         Config.load_backends

--- a/spec/unit/interpolate_spec.rb
+++ b/spec/unit/interpolate_spec.rb
@@ -165,11 +165,11 @@ describe "Hiera" do
     end
 
     it 'should not find a subkey that is matched within a string' do
-      expect{ hiera.lookup('ipl_key', nil, {}) }.to raise_error(/Got String when a hash-like object was expected to enable lookup using key 'subkey'/)
+      expect{ hiera.lookup('ipl_key', nil, {}) }.to raise_error(/Got String when a hash-like object was expected to access value using 'subkey' from key 'key.subkey'/)
     end
 
     it 'should not find a subkey that is matched within a string' do
-      expect{ hiera.lookup('key.subkey', nil, {}) }.to raise_error(/Got String when a hash-like object was expected to enable lookup using key 'subkey'/)
+      expect{ hiera.lookup('key.subkey', nil, {}) }.to raise_error(/Got String when a hash-like object was expected to access value using 'subkey' from key 'key.subkey'/)
     end
   end
 


### PR DESCRIPTION
This commit removes mentioning of 'segmented keys' in favor of wording
using 'dotted keys' and 'access' and adds the offending key to related
error messages.