### PR TITLE
(HI-510) Look for hiera.yaml in codedir first, then confdir

### DIFF
--- a/bin/hiera
+++ b/bin/hiera
@@ -28,7 +28,7 @@ require 'pp'
 
 options = {
   :default => nil,
-  :config  => File.join(Hiera::Util.config_dir, 'hiera.yaml'),
+  :config  => nil,
   :scope   => {},
   :key     => nil,
   :verbose => false,

--- a/lib/hiera.rb
+++ b/lib/hiera.rb
@@ -40,9 +40,13 @@ class Hiera
   # If the config option is a string its assumed to be a filename,
   # else a hash of what would have been in the YAML config file
   def initialize(options={})
-    options[:config] ||= File.join(Util.config_dir, 'hiera.yaml')
-
-    @config = Config.load(options[:config])
+    config = options[:config]
+    if config.nil?
+      # Look in codedir first, then confdir
+      config = File.join(Util.code_dir, 'hiera.yaml')
+      config = File.join(Util.config_dir, 'hiera.yaml') unless File.exist?(config)
+    end
+    @config = Config.load(config)
 
     Config.load_backends
   end

--- a/lib/hiera/util.rb
+++ b/lib/hiera/util.rb
@@ -26,18 +26,22 @@ class Hiera
 
     def config_dir
       if microsoft_windows?
-         File.join(common_appdata, 'PuppetLabs', 'code')
+         File.join(common_appdata, 'PuppetLabs', 'puppet', 'etc')
+      else
+        '/etc/puppetlabs/puppet'
+      end
+    end
+
+    def code_dir
+      if microsoft_windows?
+        File.join(common_appdata, 'PuppetLabs', 'code')
       else
         '/etc/puppetlabs/code'
       end
     end
 
     def var_dir
-      if microsoft_windows?
-        File.join(common_appdata, 'PuppetLabs', 'code', 'environments' , '%{environment}' , 'hieradata')
-      else
-        '/etc/puppetlabs/code/environments/%{environment}/hieradata'
-      end
+      File.join(code_dir, 'environments' , '%{environment}' , 'hieradata')
     end
 
     def file_alt_separator

--- a/spec/unit/util_spec.rb
+++ b/spec/unit/util_spec.rb
@@ -23,13 +23,26 @@ describe Hiera::Util do
   describe 'Hiera::Util.config_dir' do
     it 'should return the correct path for posix systems' do
       Hiera::Util.expects(:file_alt_separator).returns(nil)
-      expect(Hiera::Util.config_dir).to eq('/etc/puppetlabs/code')
+      expect(Hiera::Util.config_dir).to eq('/etc/puppetlabs/puppet')
     end
 
     it 'should return the correct path for microsoft windows systems' do
       Hiera::Util.expects(:microsoft_windows?).returns(true)
       Hiera::Util.expects(:common_appdata).returns('C:\\ProgramData')
-      expect(Hiera::Util.config_dir).to eq('C:\\ProgramData/PuppetLabs/code')
+      expect(Hiera::Util.config_dir).to eq('C:\\ProgramData/PuppetLabs/puppet/etc')
+    end
+  end
+
+  describe 'Hiera::Util.code_dir' do
+    it 'should return the correct path for posix systems' do
+      Hiera::Util.expects(:file_alt_separator).returns(nil)
+      expect(Hiera::Util.code_dir).to eq('/etc/puppetlabs/code')
+    end
+
+    it 'should return the correct path for microsoft windows systems' do
+      Hiera::Util.expects(:microsoft_windows?).returns(true)
+      Hiera::Util.expects(:common_appdata).returns('C:\\ProgramData')
+      expect(Hiera::Util.code_dir).to eq('C:\\ProgramData/PuppetLabs/code')
     end
   end
 


### PR DESCRIPTION
This commit ensures that when Hiera is initialized, it will first check
if a config file is specified using a CLI option. If it is, then that
config will be used (and an error is raised if it doesn't exist). When
no CLI option is used, Hiera will first look `hiera.yaml` in the
codedir and if no such file exists, it will default to `hiera.yaml`
in confdir.