### PR TITLE
(HI-528) Remove json_pure dependency

### DIFF
--- a/.gemspec
+++ b/.gemspec
@@ -29,16 +29,4 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.rubygems_version = "1.8.25"
   s.summary = "Light weight hierarchical data store"
-
-  if s.respond_to? :specification_version then
-    s.specification_version = 3
-
-    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<json_pure>, [">= 0"])
-    else
-      s.add_dependency(%q<json_pure>, [">= 0"])
-    end
-  else
-    s.add_dependency(%q<json_pure>, [">= 0"])
-  end
 end

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,6 @@ group :development, :test do
   gem 'rspec', "~> 3.3", :require => false
   gem "rspec-legacy_formatters", "~> 1.0", :require => false
   gem 'mocha', "~> 0.10.5", :require => false
-  gem 'json', "~> 1.7", :require => false, :platforms => :ruby
   gem "yarjuf", "~> 2.0"
 end
 

--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -12,8 +12,6 @@ gem_files: '{bin,lib}/**/* COPYING README.md LICENSE'
 gem_require_path: 'lib'
 gem_test_files: 'spec/**/*'
 gem_executables: 'hiera'
-gem_runtime_dependencies:
-  json_pure:
 gem_default_executables: 'hiera'
 gem_platform_dependencies:
   x86-mingw32:


### PR DESCRIPTION
json_pure was added as a dependency to hiera to enable easier development
with ruby 1.8.7 (which doesn't include a json implementation). With hiera
now supporting only ruby 1.9.3+, the dependency is no longer needed.