### PR TITLE
 report when we have skipped "bad definition in :hierarchy"

### DIFF
--- a/lib/hiera/backend.rb
+++ b/lib/hiera/backend.rb
@@ -89,7 +89,11 @@ class Hiera
 
         hierarchy.flatten.map do |source|
           source = interpolate_config(source, scope, override)
-          yield(source) unless source == "" or source =~ /(^\/|\/\/|\/$)/
+          if source == "" or source =~ /(^\/|\/\/|\/$)/
+            Hiera.debug("Ignoring bad definition in :hierarchy: \'#{source}\'")
+          else
+            yield(source)
+          end
         end
       end
 


### PR DESCRIPTION
As per discussion in Puppetlabs git ticket [HI-530](https://tickets.puppetlabs.com/browse/HI-530) 

 report when we have skipped "bad definition in :hierarchy"