### PR TITLE
Allow multiple literals in one line

### DIFF
--- a/lib/hiera/recursive_guard.rb
+++ b/lib/hiera/recursive_guard.rb
@@ -9,7 +9,7 @@ class Hiera::RecursiveGuard
   end
 
   def check(value, &block)
-    if @seen.include?(value) and value !~ "literal('\w')"
+    if @seen.include?(value) and value != "literal('%')"
       raise Hiera::InterpolationLoop, "Lookup recursion detected in [#{@seen.join(', ')}]"
     end
     @seen.push(value)

--- a/lib/hiera/recursive_guard.rb
+++ b/lib/hiera/recursive_guard.rb
@@ -9,7 +9,7 @@ class Hiera::RecursiveGuard
   end
 
   def check(value, &block)
-    if @seen.include?(value)
+    if @seen.include?(value) and value !~ "literal('\w')"
       raise Hiera::InterpolationLoop, "Lookup recursion detected in [#{@seen.join(', ')}]"
     end
     @seen.push(value)


### PR DESCRIPTION
If you try to use literal more than once per line this will fail since it already has been included. I have written something to simple check if it is a literal keyword or not. I am sure this isn't the right way to do this but I want to make you aware of it.

I am using it like the following:

```yaml
hiera::hierarchy:
   - "nodes/%{literal('%')}{::environment}/%{literal('%')}{::fqdn}"
```