### PR TITLE
Revert "(HI-538) Update beaker version to 3.1.0"

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -10,7 +10,7 @@ def location_for(place, fake_version = nil)
   end
 end
 
-gem "beaker", *location_for(ENV['BEAKER_VERSION'] || "~> 3.1.0")
+gem "beaker", *location_for(ENV['BEAKER_VERSION'] || "~> 2.32")
 gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 0.3")
 gem 'rake', "~> 10.1.0"
 


### PR DESCRIPTION
This reverts commit bf52672cee19a9d712394c0acdedb05f5970e93f.

All jenkins pipelines for hiera need to be updated to use ruby >= 2.2.5 before
this will work