### PR TITLE
(packaging) Bump version to 3.2.2

### DIFF
--- a/lib/hiera/version.rb
+++ b/lib/hiera/version.rb
@@ -7,7 +7,7 @@
 
 
 class Hiera
-  VERSION = "3.3.0"
+  VERSION = "3.2.2"
 
   ##
   # version is a public API method intended to always provide a fast and


### PR DESCRIPTION
This updates Hiera's version to 3.2.2 in preparation for the
puppet-agent 1.8.0 release. We had originally updated the version from
3.2.1 to 3.3.0, but the small amount of changes made a Y release
unnecessary.