### PR TITLE
Merge master to stable

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -10,7 +10,7 @@ def location_for(place, fake_version = nil)
   end
 end
 
-gem "beaker", *location_for(ENV['BEAKER_VERSION'] || "~> 2.32")
+gem "beaker", *location_for(ENV['BEAKER_VERSION'] || "~> 3.1.0")
 gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 0.3")
 gem 'rake', "~> 10.1.0"
 

--- a/lib/hiera/backend.rb
+++ b/lib/hiera/backend.rb
@@ -89,7 +89,11 @@ class Hiera
 
         hierarchy.flatten.map do |source|
           source = interpolate_config(source, scope, override)
-          yield(source) unless source == "" or source =~ /(^\/|\/\/|\/$)/
+          if source == "" or source =~ /(^\/|\/\/|\/$)/
+            Hiera.debug("Ignoring bad definition in :hierarchy: \'#{source}\'")
+          else
+            yield(source)
+          end
         end
       end
 

--- a/lib/hiera/version.rb
+++ b/lib/hiera/version.rb
@@ -7,7 +7,7 @@
 
 
 class Hiera
-  VERSION = "3.2.1"
+  VERSION = "3.2.2"
 
   ##
   # version is a public API method intended to always provide a fast and


### PR DESCRIPTION
This merge is in anticipation of the puppet-agent 1.8.0 release, and includes the 3.2.2 tag, along with everything slated for that release.