### PR TITLE
(PA-652) Bump Hiera version to 3.2.3

### DIFF
--- a/lib/hiera/version.rb
+++ b/lib/hiera/version.rb
@@ -7,7 +7,7 @@
 
 
 class Hiera
-  VERSION = "3.2.2"
+  VERSION = "3.2.3"
 
   ##
   # version is a public API method intended to always provide a fast and


### PR DESCRIPTION
This bumps the Hiera version to 3.2.3 following the release of 3.2.2 as
part of puppet-agent 1.8.0.