### PR TITLE
(HI-538) Update beaker version to 3.1.0

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -10,7 +10,7 @@ def location_for(place, fake_version = nil)
   end
 end
 
-gem "beaker", *location_for(ENV['BEAKER_VERSION'] || "~> 2.32")
+gem "beaker", *location_for(ENV['BEAKER_VERSION'] || "~> 3.1.0")
 gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 0.3")
 gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || "~> 0.2")
 gem 'rake', "~> 10.1.0"


### PR DESCRIPTION
Update the beaker gem version used in acceptance to beaker 3.1.0 to allow for
MacOS Sierra (10.12) testing.

This is a cherry-pick to the LTS branch