### PR TITLE
(HI-519) Read files in with unicode

### DIFF
--- a/lib/hiera/filecache.rb
+++ b/lib/hiera/filecache.rb
@@ -49,7 +49,7 @@ class Hiera
     # in processing will be propagated to the caller
     def read_file(path, expected_type = Object)
       if stale?(path)
-        data = File.read(path)
+        data = File.read(path, :encoding => 'BOM|UTF-8')
         @cache[path][:data] = block_given? ? yield(data) : data
 
         if !@cache[path][:data].is_a?(expected_type)

--- a/spec/unit/filecache_spec.rb
+++ b/spec/unit/filecache_spec.rb
@@ -84,6 +84,36 @@ class Hiera
         end
       end
 
+      it "sets the encoding to UTF-8 when reading a file" do
+        begin
+          original_encoding = Encoding.default_external
+          Encoding.default_external = Encoding::ISO_8859_1
+
+          Dir.mktmpdir do |dir|
+            file = File.join(dir, "testing")
+            write_file(file, "my data")
+            expect(@cache.read_file(file).encoding).to eq(Encoding::UTF_8)
+          end
+        ensure
+          Encoding.default_external = original_encoding
+        end
+      end
+
+      it "reads a file with unicode characters" do
+        begin
+          original_encoding = Encoding.default_external
+          Encoding.default_external = Encoding::ISO_8859_1
+
+          Dir.mktmpdir do |dir|
+            file = File.join(dir, "testing")
+            write_file(file, "\u2603")
+            expect(@cache.read_file(file)).to eq("\u2603")
+          end
+        ensure
+          Encoding.default_external = original_encoding
+        end
+      end
+
       it "rereads data when the file changes" do
         Dir.mktmpdir do |dir|
           file = File.join(dir, "testing")


### PR DESCRIPTION
Unless supplied an encoding, File.read will read in files with whatever Ruby's
default external encoding is, which on Windows may be an encoding such as
IBM437. Prior to this commit, hiera's FileCache#read_file method would call
File.read without an encoding, which could be problematic when reading files
containing unicode or other characters undefined on such a platform. This
commit updates the #read_file method to explicitly read files in with
BOM|UTF-8.