### PR TITLE
(packaging) Bump Hiera version to 3.3.0

### DIFF
--- a/lib/hiera/version.rb
+++ b/lib/hiera/version.rb
@@ -7,7 +7,7 @@
 
 
 class Hiera
-  VERSION = "3.2.3"
+  VERSION = "3.3.0"
 
   ##
   # version is a public API method intended to always provide a fast and


### PR DESCRIPTION
Bump Hiera to v3.3.0, which will be included in puppet-agent 1.9.0.