### PR TITLE
(HI-544) Fail with meaningful message on hiera configs with version > 3

### DIFF
--- a/lib/hiera/config.rb
+++ b/lib/hiera/config.rb
@@ -26,7 +26,13 @@ class Hiera::Config
                        raise detail
                      end
                    end
-          @config.merge! config if config
+          if config
+            version = config['version'] || config[:version] || 3
+            if version >= 4
+              raise "v4 hiera.yaml is only to be used inside an environment or a module and cannot be given to the global hiera"
+            end
+            @config.merge! config
+          end
         else
           raise "Config file #{source} not found"
         end

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -12,6 +12,10 @@ class Hiera
         }
       end
 
+      it 'should raise an error if the configuration version is greater than 3' do
+        expect { Hiera.new(:config => File.join(HieraSpec::FIXTURE_DIR, 'badconfig', 'config', 'hiera.yaml')) }.to raise_error(/v4 hiera\.yaml is only to be used inside an environment or a module/)
+      end
+
       it "should raise an error for missing config files" do
         File.expects(:exist?).with("/nonexisting").returns(false)
         YAML.expects(:load_file).with("/nonexisting").never

--- a/spec/unit/fixtures/badconfig/config/hiera.yaml
+++ b/spec/unit/fixtures/badconfig/config/hiera.yaml
@@ -1,0 +1,6 @@
+---
+:version: 4
+:hierarchy:
+  - :name: "common"
+    :backend: yaml
+:datadir: "data"

--- a/spec/unit/fixtures/badconfig/data/common.yaml
+++ b/spec/unit/fixtures/badconfig/data/common.yaml
@@ -1,0 +1,2 @@
+foo: '%{hiera("bar")}'
+bar: 'common'


### PR DESCRIPTION
This commit adds a check for a `version` field in the hiera.yaml config
file. If the version is present and indicates a number greater than 3, then
the load fails with an error.

This is a cherry-pick of fd10d3f16b0f319af817ea494ae768ea7e350a32 to
reapply the patch following a mistaken revert.