### PR TITLE
(HI-346) Remove unnecessary Windows gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,22 +15,6 @@ group :development, :test do
   gem "yarjuf", "~> 2.0"
 end
 
-
-require 'yaml'
-data = YAML.load_file(File.join(File.dirname(__FILE__), 'ext', 'project_data.yaml'))
-bundle_platforms = data['bundle_platforms']
-data['gem_platform_dependencies'].each_pair do |gem_platform, info|
-  next if gem_platform =~ /mingw/
-  if bundle_deps = info['gem_runtime_dependencies']
-    bundle_platform = bundle_platforms[gem_platform] or raise "Missing bundle_platform"
-    platform(bundle_platform.intern) do
-      bundle_deps.each_pair do |name, version|
-        gem(name, version, :require => false)
-      end
-    end
-  end
-end
-
 if File.exists? "#{__FILE__}.local"
   eval(File.read("#{__FILE__}.local"), binding)
 end

--- a/Gemfile
+++ b/Gemfile
@@ -31,10 +31,6 @@ data['gem_platform_dependencies'].each_pair do |gem_platform, info|
   end
 end
 
-platform(:mingw_19) do
-  gem 'win32console', '~> 1.3.2', :require => false
-end
-
 mingw = [:mingw]
 mingw << :x64_mingw if Bundler::Dsl::VALID_PLATFORMS.include?(:x64_mingw)
 

--- a/Gemfile
+++ b/Gemfile
@@ -31,12 +31,6 @@ data['gem_platform_dependencies'].each_pair do |gem_platform, info|
   end
 end
 
-mingw = [:mingw]
-mingw << :x64_mingw if Bundler::Dsl::VALID_PLATFORMS.include?(:x64_mingw)
-
-platform(*mingw) do
-  gem 'win32-dir', '~> 0.4.8', :require => false
-end
 if File.exists? "#{__FILE__}.local"
   eval(File.read("#{__FILE__}.local"), binding)
 end

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,66 @@
+version: 3.3.1.{build}
+clone_depth: 10
+install:
+build: off
+matrix:
+  fast_finish: true
+
+# Ruby versions under test
+platform:
+  - Ruby23-x64
+  - Ruby21-x64
+
+# Note that locales are mainly code page changes and are not the FULL set of localization
+#  changes that happen when you install French/Germam/Japanese etc. Windows
+environment:
+  matrix:
+  - LOCALE: en-US
+  - LOCALE: ja-JP
+
+before_test:
+  # Semicolons are required below.  This renders as a single line powershell command in AppVeyor
+  - ps: >-
+      [string]$testLocale = [Environment]::GetEnvironmentVariable("LOCALE","Process");
+      $currentLocale = (Get-WinSystemLocale).Name;
+      if ($testLocale -ne '') {
+        if ($testLocale -ne $currentLocale) {
+          Write-Output "Setting Locale to $testLocale ...";
+          Set-WinSystemLocale ($testLocale);
+          Write-Output "Restarting worker in 5 seconds...";
+          Start-Sleep -Seconds 5
+          Restart-Computer -Force -Confirm:$false;
+        } else {
+          Write-Output "Locale is already set to $currentLocale";
+        };
+      } else {
+        Write-Output "LOCALE environment variable not set";
+      };
+
+test_script:
+  # The sleep is needed to allow the Appveyor tracing to start correctly after a reboot (locale change)
+  # - ps: Start-Sleep -Seconds 5
+  - timeout 6
+  - ps: |
+      chcp
+      Get-WinSystemLocale
+      $Env:PATH = "C:\${Env:PLATFORM}\bin;${Env:PATH}"
+      $Env:LOG_SPEC_ORDER = 'true'
+      Get-ChildItem Env: | % { Write-Output "$($_.Key): $($_.Value)"  }
+      bundle install --jobs 4 --retry 2 --without development
+      Get-Content Gemfile.lock
+      ruby -v
+      gem --version
+      bundle --version
+      bundle exec rake spec
+      $exitCode = $LASTEXITCODE
+      Write-Output "Spec run exited with $exitCode"
+      $host.SetShouldExit($exitCode)
+on_failure:
+  - appveyor PushArtifact .\spec_order.txt
+notifications:
+  - provider: Email
+    to:
+    - nobody@nowhere.com
+    on_build_success: false
+    on_build_failure: false
+    on_build_status_changed: false

--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -16,7 +16,6 @@ gem_default_executables: 'hiera'
 gem_platform_dependencies:
   x86-mingw32:
     gem_runtime_dependencies:
-      win32console: '1.3.2'
       win32-dir: '~> 0.4.8'
   x64-mingw32:
     gem_runtime_dependencies:

--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -16,10 +16,8 @@ gem_default_executables: 'hiera'
 gem_platform_dependencies:
   x86-mingw32:
     gem_runtime_dependencies:
-      win32-dir: '~> 0.4.8'
   x64-mingw32:
     gem_runtime_dependencies:
-      win32-dir: '~> 0.4.8'
 bundle_platforms:
   x86-mingw32: mingw
   x64-mingw32: x64_mingw

--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -13,11 +13,3 @@ gem_require_path: 'lib'
 gem_test_files: 'spec/**/*'
 gem_executables: 'hiera'
 gem_default_executables: 'hiera'
-gem_platform_dependencies:
-  x86-mingw32:
-    gem_runtime_dependencies:
-  x64-mingw32:
-    gem_runtime_dependencies:
-bundle_platforms:
-  x86-mingw32: mingw
-  x64-mingw32: x64_mingw

--- a/install.rb
+++ b/install.rb
@@ -147,14 +147,10 @@ def prepare_installation
   if InstallOptions.configdir
     configdir = InstallOptions.configdir
   elsif is_windows?
-    begin
-      require 'rubygems'
-      require 'win32/dir'
-    rescue LoadError => e
-      puts "Cannot run on Microsoft Windows without the sys-admin, win32-process, win32-dir & win32-service gems: #{e}"
-      exit(-1)
-    end
-    configdir = File.join(Dir::COMMON_APPDATA, "PuppetLabs", "hiera", "etc")
+    path = File.join(File.dirname(__FILE__), "lib", "hiera", "util", "win32")
+    require_relative(path)
+
+    configdir = File.join(Hiera::Util::Win32.get_common_appdata(), "PuppetLabs", "hiera", "etc")
   else
     configdir = "/etc"
   end

--- a/lib/hiera.rb
+++ b/lib/hiera.rb
@@ -5,6 +5,7 @@ class Hiera
   require "hiera/version"
   require "hiera/config"
   require "hiera/util"
+  require "hiera/util/win32"
   require "hiera/backend"
   require "hiera/console_logger"
   require "hiera/puppet_logger"

--- a/lib/hiera/util.rb
+++ b/lib/hiera/util.rb
@@ -13,15 +13,7 @@ class Hiera
     end
 
     def microsoft_windows?
-      return false unless file_alt_separator
-
-      begin
-        require 'win32/dir'
-        true
-      rescue LoadError => err
-        warn "Cannot run on Microsoft Windows without the win32-dir gem: #{err}"
-        false
-      end
+      !!file_alt_separator
     end
 
     def config_dir
@@ -49,7 +41,7 @@ class Hiera
     end
 
     def common_appdata
-      Dir::COMMON_APPDATA
+      @common_appdata ||= Hiera::Util::Win32.get_common_appdata()
     end
 
     def split_key(key)

--- a/lib/hiera/util/win32.rb
+++ b/lib/hiera/util/win32.rb
@@ -1,0 +1,40 @@
+class Hiera
+  module Util
+    module Win32
+      if !!File::ALT_SEPARATOR
+        require 'fiddle/import'
+        require 'fiddle/types'
+
+        # import, dlload, include and typealias must be ordered this way
+        extend Fiddle::Importer
+        dlload 'shell32'
+        include Fiddle::Win32Types # adds HWND, HANDLE, DWORD type aliases
+        typealias 'LPWSTR', 'wchar_t*'
+        typealias 'LONG', 'long'
+        typealias 'HRESULT','LONG'
+
+        # https://msdn.microsoft.com/en-us/library/windows/desktop/aa383751(v=vs.85).aspx
+        # HRESULT SHGetFolderPath(
+        #   _In_  HWND   hwndOwner,
+        #   _In_  int    nFolder,
+        #   _In_  HANDLE hToken,
+        #   _In_  DWORD  dwFlags,
+        #   _Out_ LPTSTR pszPath
+        # );
+        extern 'HRESULT SHGetFolderPathW(HWND, int, HANDLE, DWORD, LPWSTR)'
+
+        COMMON_APPDATA = 0x0023
+        S_OK           = 0x0
+        MAX_PATH       = 260;
+
+        def self.get_common_appdata
+          # null terminated MAX_PATH string in wchar (i.e. 2 bytes per char)
+          buffer = 0.chr * ((MAX_PATH + 1) * 2)
+          result = SHGetFolderPathW(0, COMMON_APPDATA, 0, 0, buffer)
+          raise "Could not find COMMON_APPDATA path - HRESULT: #{result}" unless result == S_OK
+          buffer.force_encoding(Encoding::UTF_16LE).encode(Encoding::UTF_8).strip
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,13 +9,6 @@ require 'tmpdir'
 RSpec.configure do |config|
   config.mock_with :mocha
 
-  if Hiera::Util.microsoft_windows? && RUBY_VERSION =~ /^1\./
-    require 'win32console'
-    config.output_stream = $stdout
-    config.error_stream = $stderr
-    config.formatters.each { |f| f.instance_variable_set(:@output, $stdout) }
-  end
-
   config.after :suite do
     # Log the spec order to a file, but only if the LOG_SPEC_ORDER environment variable is
     #  set.  This should be enabled on Jenkins runs, as it can be used with Nick L.'s bisect


### PR DESCRIPTION
* Adds AppVeyor support for pull requests
* Removes win32console gem
* Removes win32-dir gem / replaces COMMON_APPDATA resolution with call to Windows API `SHGetFolderPath`
* Removes `project_data.yaml` gem definitions - resulting in no more platform specific gems for Windows