### PR TITLE
(maint) Update contributing resource links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,9 +57,10 @@ things.
 
 # Additional Resources
 
-* [More information on contributing](http://links.puppet.com/contribute-to-puppet)
+* [Puppet community guidelines](https://docs.puppet.com/community/community_guidelines.html)
 * [Bug tracker (Jira)](http://tickets.puppetlabs.com)
 * [Contributor License Agreement](http://links.puppet.com/cla)
 * [General GitHub documentation](http://help.github.com/)
 * [GitHub pull request documentation](http://help.github.com/send-pull-requests/)
 * #puppet-dev IRC channel on freenode.org
+* [puppet-dev mailing list](https://groups.google.com/forum/#!forum/puppet-dev)


### PR DESCRIPTION
This commit replaces the stale link to the old puppet wiki with a link to the
contributor guidelines, and adds a link to the puppet-dev email list.