### PR TITLE
(HI-575) Enable rubocop/securitycop scans

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,22 @@
+AllCops:
+  Include:
+    - 'lib/**/*.rb'
+    - 'ext/**/*.rb'
+  Exclude:
+    - 'Gemfile'
+    - '**/*.erb'
+    - '**/*.spec'
+    - 'acceptance/**/*'
+    - 'spec/**/*'
+    - 'tasks/**/*'
+
+  DisabledByDefault: true
+
+Security/YAMLLoad:
+   Enabled: true
+
+Security/MarshalLoad:
+   Enabled: true
+
+Security/Eval:
+   Enabled: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ rvm:
 env:
   - "CHECK=spec"
   - "CHECK=commits"
+  - "CHECK=rubocop"
 
 matrix:
   exclude:
@@ -21,7 +22,10 @@ matrix:
       env: "CHECK=commits"
     - rvm: 2.2.4
       env: "CHECK=commits"
+      env: "CHECK=rubocop"
     - rvm: 2.0.0
       env: "CHECK=commits"
+      env: "CHECK=rubocop"
     - rvm: 1.9.3
       env: "CHECK=commits"
+      env: "CHECK=rubocop"

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,11 @@ group :development, :test do
   gem "rspec-legacy_formatters", "~> 1.0", :require => false
   gem 'mocha', "~> 0.10.5", :require => false
   gem "yarjuf", "~> 2.0"
+  if RUBY_VERSION =~ /^1\.9\.3/
+    # No rubocop
+  else
+    gem "rubocop", "~> 0.48.1", :platforms => [:ruby], :require => false
+  end
 end
 
 if File.exists? "#{__FILE__}.local"

--- a/Rakefile
+++ b/Rakefile
@@ -52,6 +52,13 @@ task :spec do
   sh %{rspec #{ENV['TEST'] || ENV['TESTS'] || 'spec'}}
 end
 
+desc 'run static analysis with rubocop'
+task(:rubocop) do
+  require 'rubocop'
+  cli = RuboCop::CLI.new
+  exit_code = cli.run(%w(--display-cop-names --format simple))
+  raise "RuboCop detected offenses" if exit_code != 0
+end
 task :test => :spec
 
 desc "verify that commit messages match CONTRIBUTING.md requirements"

--- a/bin/hiera
+++ b/bin/hiera
@@ -100,7 +100,14 @@ def load_scope(source, type=:yaml)
       require 'puppet'
       Puppet.settings.parse
       Puppet::Node::Facts.indirection.terminus_class = :rest
-      scope = YAML.load(Puppet::Node::Facts.indirection.find(source).to_yaml)
+
+      # HI-575: Use YAML safe_load where we can.
+      if YAML.respond_to? :safe_load
+        scope = YAML.safe_load(Puppet::Node::Facts.indirection.find(source).to_yaml)
+      else
+        scope = YAML.load(Puppet::Node::Facts.indirection.find(source).to_yaml)  # rubocop:disable Security/YAMLLoad
+      end
+
       # Puppet makes dumb yaml files that do not promote data reuse.
       scope = scope.values if scope.is_a?(Puppet::Node::Facts)
     rescue Exception => e

--- a/lib/hiera/backend/yaml_backend.rb
+++ b/lib/hiera/backend/yaml_backend.rb
@@ -16,7 +16,12 @@ class Hiera
 
         Backend.datasourcefiles(:yaml, scope, "yaml", order_override) do |source, yamlfile|
           data = @cache.read_file(yamlfile, Hash) do |data|
-            YAML.load(data) || {}
+	    # HI-575: Use YAML safe_load where we can.
+            if YAML.respond_to? :safe_load
+	      YAML.safe_load(data) || {}
+	    else
+	      YAML.load(data) || {} # rubocop:disable Security/YAMLLoad
+	    end
           end
 
           next if data.empty?


### PR DESCRIPTION
This is more of a precautionary measure to avoid inadvertent use of any insecure language constructs in future. 

  - Added rubocop config file for rules, inclusions, exclusions
  - Updated .travis.yml, Gemfile and Rakefile to initiate rubocop scans
  - Changed instances of YAML.load in lib/hiera/backend/yaml_backend.rb and bin/hiera (if safe_load available)
Spec/unit tests and acceptance tests pass. 