### PR TITLE
(packaging) Bump version to 3.4.0

### DIFF
--- a/lib/hiera/version.rb
+++ b/lib/hiera/version.rb
@@ -7,7 +7,7 @@
 
 
 class Hiera
-  VERSION = "3.3.1"
+  VERSION = "3.4.0"
 
   ##
   # version is a public API method intended to always provide a fast and


### PR DESCRIPTION
This commit updates the version of Hiera to 3.4.0 in preparation for the
Puppet Agent 5.0.0 release.