### PR TITLE
(HI-579) Begin hard-coding hiera version in the gemspec

### DIFF
--- a/.gemspec
+++ b/.gemspec
@@ -5,16 +5,9 @@
 # repository](https://github.com/puppetlabs/packaging) for information on how
 # to build release packages.
 
-begin
-  require 'hiera/version'
-rescue LoadError
-  $LOAD_PATH.unshift(File.expand_path("../lib", __FILE__))
-  require 'hiera/version'
-end
-
 Gem::Specification.new do |s|
   s.name = "hiera"
-  version = Hiera.version
+  version = "3.4.0"
   mdata = version.match(/(\d+\.\d+\.\d+)/)
   s.version = mdata ? mdata[1] : version
 


### PR DESCRIPTION
Rubygems has some undesirable behavior when doing dependency solving
with versions that are looked up from within a library. This can be seen
when using the rubygems in the puppet-agent package to install r10k, and
then installing a second version of a gem that r10k depends on, such as
minitar.
When more than one version of a dependent gem is installed, rubygems
loads all of the gemspecs and tries to decide which gems to activate.
When loading all of the gemspecs, rubygems encounters the require on
`hiera/version`, which brings us to the second half of our story.
Rubygems monkey patches `Kernel.require` to first search gems for a path
before searching the load path. This means that to find
`hiera/version`, rubygems first looks through all of the gems it knows
about, which means loading all of the gemspecs. It gets to the puppet
gemspec and then to the require `hiera/version` which begins the story
over again, until the stack is exhausted.
The user on the other end who might just be running r10k version gets
an error message that looks like:

```
Invalid gemspec in [/opt/puppetlabs/puppet/lib/ruby/gems/2.4.0/specifications/hiera.gemspec]: stack level too deep
Invalid gemspec in [/opt/puppetlabs/puppet/lib/ruby/gems/2.4.0/specifications/puppet.gemspec]: stack level too deep
```

One of the ways to avoid this situation is to not do a require in our
gemspec, and to instead hard-code the hiera version, which this commit
does.