### PR TITLE
(maint) Reference actual config version in error message

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,12 @@
 language: ruby
 sudo: false
+# Travis Ruby 1.9.3 stack is defaulting to version 1.7.6 of bundler
+# which is incompatible with the Rubygems 2.6.13 security release.
+#
+# TODO: Remove when Travis updates its default:
+#   https://github.com/travis-ci/travis-ci/issues/8357
+before_install:
+  - gem install bundler --version 1.15.4
 bundler_args: --without development
 script: "bundle exec rake $CHECK"
 notifications:

--- a/lib/hiera/config.rb
+++ b/lib/hiera/config.rb
@@ -29,7 +29,7 @@ class Hiera::Config
           if config
             version = config['version'] || config[:version] || 3
             if version >= 4
-              raise "v4 hiera.yaml is only to be used inside an environment or a module and cannot be given to the global hiera"
+              raise "v#{version} hiera.yaml is only to be used inside an environment or a module and cannot be given to the global hiera"
             end
             @config.merge! config
           end
@@ -48,7 +48,7 @@ class Hiera::Config
         @config[:logger] = "console"
         Hiera.logger = "console"
       end
-    
+
       self.validate!
 
       @config


### PR DESCRIPTION
Now that hiera 5 configs exist this error message can be thrown from a
hiera 5 config in which case the error message is very confusing. This
commit includes the actual hiera config version in the error message
instead of assuming it will be 4.