### PR TITLE
(HI-585) Enable testing system openssl linked PA in CI pipelines on rhel7

### DIFF
--- a/acceptance/setup/aio/pre-suite/010_Install.rb
+++ b/acceptance/setup/aio/pre-suite/010_Install.rb
@@ -42,8 +42,8 @@ step "Enable FIPS on agent hosts..." do
  # There might be a better way to do some things below but till then...
  # The TODO's need to be followed up
 
-  agents.each do |agent|
-    next if agent == master # Only on agents.
+ # agents.each do |agent|
+ #   next if agent == master # Only on agents.
 
     # Do this only on rhel7, rhel6, f24, f25
     use_system_openssl = ENV['USE_SYSTEM_OPENSSL']
@@ -106,5 +106,5 @@ step "Enable FIPS on agent hosts..." do
       on agent, puppet('config set digest_algorithm sha256')
       
     end
-  end
+  # end
 end

--- a/acceptance/setup/aio/pre-suite/010_Install.rb
+++ b/acceptance/setup/aio/pre-suite/010_Install.rb
@@ -35,3 +35,76 @@ agents.each do |agent|
   ruby = Puppet::Acceptance::CommandUtils.ruby_command(agent)
   on agent, "#{ruby} --version"
 end
+
+
+step "Enable FIPS on agent hosts..." do
+
+ # There might be a better way to do some things below but till then...
+ # The TODO's need to be followed up
+
+  agents.each do |agent|
+    next if agent == master # Only on agents.
+
+    # Do this only on rhel7, rhel6, f24, f25
+    use_system_openssl = ENV['USE_SYSTEM_OPENSSL']
+    if use_system_openssl
+      # Other platforms to come...
+      next if !agent[:platform].match(/(?:el-7|redhat-7)/)
+
+      # Step 1: Disable prelinking
+      # TODO:: Handle cases where the /etc/sysconfig/prelink might exist
+      on(agent, 'echo "PRELINKING=no" > /etc/sysconfig/prelink')
+      # TODO: prelink is commented till we figure how to attempt executing
+      # it so any failures do not cause this thing to exit
+      # on(agent, "prelink -u -a")
+ 
+      # Step 2: Install dracut-fips, dracut-fips-aesni
+      on(agent, "yum -y install dracut-fips")
+      on(agent, "yum -y install dracut-fips-aesni")
+
+      # TODO:: Backup existing kernel image in case anything goes south..
+      # Step 3: Run dracut to update system for fips. 
+      on(agent, "dracut -v -f")
+
+
+      # TODO:: Steps 4 and 5 need to be adjusted for rhel6, f24, f25
+      # as the method of enabling FIPS are different on those platforms. 
+      # Below works on rhel7
+      
+      # Step 4: Find out the device details (BLOCK ID) of boot partition
+      # append enable fips and boot block id to kernel command line in grub file
+      
+      on(agent, 'boot_blkid=$(blkid `df /boot | grep "/dev" | awk \'BEGIN{ FS=" "}; {print $1}\'` | awk \'BEGIN{ FS=" "}; {print $2}\' | sed \'s/"//g\');\
+                 fips_bootblk="fips=1 boot="$boot_blkid;\
+                 grub_linux_cmdline=`grep -e "^GRUB_CMDLINE_LINUX" /etc/default/grub | sed "s/\"$/ $fips_bootblk\"/"`;\
+                 grep -v GRUB_CMDLINE_LINUX /etc/default/grub > /etc/default/grub.bak;\
+                 /bin/cp -rf /etc/default/grub.bak /etc/default/grub;\
+                 sed -i "/GRUB_DISABLE_RECOVERY/i $grub_linux_cmdline" /etc/default/grub')
+
+
+      # Step 5: Run grub2 mkconfig to make the changes take effect.
+      on(agent, 'grub2-mkconfig -o /boot/grub2/grub.cfg')
+
+      # Reboot is needed for the system to start in FIPS mode
+      agent.reboot
+      timeout = 30
+      begin
+        Timeout.timeout(timeout) do
+          until agent.up?
+            sleep 1
+          end
+        end
+      rescue Timeout::Error => e
+        raise "Agent did not come back up within #{timeout} seconds."
+      end
+      
+      # TODO:
+      # Ensure that agent is actually in fips mode by examining the contents of
+      # /proc/sys/crypto/fips_enabled and that it is 1
+
+      # Switch to using sha256 to work in fips mode.
+      on agent, puppet('config set digest_algorithm sha256')
+      
+    end
+  end
+end

--- a/acceptance/setup/aio/pre-suite/010_Install.rb
+++ b/acceptance/setup/aio/pre-suite/010_Install.rb
@@ -10,6 +10,16 @@ step "Install puppet-agent..." do
     :puppet_agent_sha     => ENV['SHA'],
     :puppet_agent_version => ENV['SUITE_VERSION'] || ENV['SHA']
   }
+
+  if agent[:platform].match(/(?:el-7|redhat-7)/)
+    step "Upgrade openssl package..." do
+    end
+    on(agent, "yum -y install openssl-1.0.1e-51.el7_2.4.x86_64")
+  else
+    step "Skipping upgrade of openssl package... (not redhat platform)" do
+    end
+  end
+
   install_puppet_agent_dev_repo_on(hosts, opts)
 end
 

--- a/acceptance/setup/aio/pre-suite/010_Install.rb
+++ b/acceptance/setup/aio/pre-suite/010_Install.rb
@@ -11,19 +11,19 @@ step "Install puppet-agent..." do
     :puppet_agent_version => ENV['SUITE_VERSION'] || ENV['SHA']
   }
 
-   # Move the openssl libs package to a newer version on redhat platforms
-   use_system_openssl = ENV['USE_SYSTEM_OPENSSL']
+  # Move the openssl libs package to a newer version on redhat platforms
+  use_system_openssl = ENV['USE_SYSTEM_OPENSSL']
 
-   if use_system_openssl && agent[:platform].match(/(?:el-7|redhat-7)/)
-     rhel7_openssl_version = ENV['RHEL7_OPENSSL_VERSION']
-     if rhel7_openssl_version.to_s.empty?
-       # Fallback to some default is none is provided
-       rhel7_openssl_version = "openssl-1.0.1e-51.el7_2.4.x86_64"
-     end
-     on(agent, "yum -y install " +  rhel7_openssl_version)
-   else
-     step "Skipping upgrade of openssl package... (" + agent[:platform] + ")" 
-   end
+  if use_system_openssl && agent[:platform].match(/(?:el-7|redhat-7)/)
+    rhel7_openssl_version = ENV['RHEL7_OPENSSL_VERSION']
+    if rhel7_openssl_version.to_s.empty?
+      # Fallback to some default is none is provided
+      rhel7_openssl_version = "openssl-1.0.1e-51.el7_2.4.x86_64"
+    end
+    on(agent, "yum -y install " +  rhel7_openssl_version)
+  else
+    step "Skipping upgrade of openssl package... (" + agent[:platform] + ")" 
+  end
 
   install_puppet_agent_dev_repo_on(hosts, opts)
 end

--- a/acceptance/setup/aio/pre-suite/010_Install.rb
+++ b/acceptance/setup/aio/pre-suite/010_Install.rb
@@ -11,14 +11,19 @@ step "Install puppet-agent..." do
     :puppet_agent_version => ENV['SUITE_VERSION'] || ENV['SHA']
   }
 
-  if agent[:platform].match(/(?:el-7|redhat-7)/)
-    step "Upgrade openssl package..." do
-    end
-    on(agent, "yum -y install openssl-1.0.1e-51.el7_2.4.x86_64")
-  else
-    step "Skipping upgrade of openssl package... (not redhat platform)" do
-    end
-  end
+   # Move the openssl libs package to a newer version on redhat platforms
+   use_system_openssl = ENV['USE_SYSTEM_OPENSSL']
+
+   if use_system_openssl && agent[:platform].match(/(?:el-7|redhat-7)/)
+     rhel7_openssl_version = ENV['RHEL7_OPENSSL_VERSION']
+     if rhel7_openssl_version.to_s.empty?
+       # Fallback to some default is none is provided
+       rhel7_openssl_version = "openssl-1.0.1e-51.el7_2.4.x86_64"
+     end
+     on(agent, "yum -y install " +  rhel7_openssl_version)
+   else
+     step "Skipping upgrade of openssl package... (" + agent[:platform] + ")" 
+   end
 
   install_puppet_agent_dev_repo_on(hosts, opts)
 end


### PR DESCRIPTION
VM images for RHEL7 use an old patch version of openssl library compared to that
on Centos7 which is used for building PA for rhel platforms. That causes failures
when running hiera acceptance tests on rhel7. They need to be upgraded with
newer version of openssl libraries.

Related to PA-1580 (part of epic PA-1608). Has been tested in PA CI - logs would be attached to PR for PA-1264 (enables linking PA against system openssl).
This does not impact regular agent build using vendored openssl which disregard system
openssl. 