### PR TITLE
(packaging) Bump to version '3.7.0' [no-promote]

### DIFF
--- a/lib/hiera/version.rb
+++ b/lib/hiera/version.rb
@@ -7,7 +7,7 @@
 
 
 class Hiera
-  VERSION = "3.6.0"
+  VERSION = "3.7.0"
 
   ##
   # version is a public API method intended to always provide a fast and


### PR DESCRIPTION
This commit bumps hiera version to 3.7.0 as 3.6.x branch was manually
created.