### PR TITLE
(RE-13431) Remove reference to 'gpg_key'

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -1,6 +1,5 @@
 ---
 packager: 'puppetlabs'
-gpg_key: '7F438280EF8D349F'
 
 # These are the build targets used by the packaging repo. Uncomment to allow use.
 #final_mocks: 'pl-el-5-i386 pl-el-6-i386 pl-el-7-x86_64'


### PR DESCRIPTION
More of a formality to remove references of our soon-to-expire GPG
key.

Under normal circumstances this setting from ext/build_defaults.yaml
is ignored in favor of https://github.com/puppetlabs/build-data/blob/5c6466dd0427773df6064b33354dedb9161d5845/builder_data.yaml#L3