### PR TITLE
(maint) upgrade rake due to CVE-2020-8130

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -16,7 +16,7 @@ gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] ||
 gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || "~> 0.5")
 gem "beaker-vagrant", *location_for(ENV['BEAKER_VMPOOLER_VERSION'] || "~> 0")
 gem "beaker-vmpooler", *location_for(ENV['BEAKER_VMPOOLER_VERSION'] || "~> 1")
-gem 'rake', "~> 10.1.0"
+gem "rake", ">= 12.3.3"
 
 if File.exists? "#{__FILE__}.local"
   eval(File.read("#{__FILE__}.local"), binding)


### PR DESCRIPTION
This is the Gemfile used during beaker testing, not the main Gemfile.