### PR TITLE
(packaging) Sets version to 3.9.0 for release

### DIFF
--- a/lib/hiera/version.rb
+++ b/lib/hiera/version.rb
@@ -7,7 +7,7 @@
 
 
 class Hiera
-  VERSION = "3.10.0"
+  VERSION = "3.9.0"
 
   ##
   # version is a public API method intended to always provide a fast and


### PR DESCRIPTION
We need to release Hiera 3.9.0 for the upcoming Puppet 6.27.0
release. In 404ea2e, our automation accidentally skipped 3.9.0
and went straight to 3.10.0.

After this is merged, I plan on running a package validation
pipeline that will add the corresponding 3.9.0 tag.