### PR TITLE
(HI-635) Adds Ruby 3.2 to rspec tests

### DIFF
--- a/.github/workflows/rspec_tests.yaml
+++ b/.github/workflows/rspec_tests.yaml
@@ -15,9 +15,10 @@ jobs:
         cfg:
           - {os: ubuntu-18.04, ruby: '2.5'}
           - {os: ubuntu-18.04, ruby: '2.7'}
-          - {os: ubuntu-18.04, ruby: '3.0'}
+          - {os: ubuntu-18.04, ruby: '3.2.0-preview2'}
           - {os: windows-2019, ruby: '2.5'}
           - {os: windows-2019, ruby: '2.7'}
+          - {os: windows-2019, ruby: '3.1'}
 
     runs-on: ${{ matrix.cfg.os }}
     steps:

--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ group :development, :test do
   gem "yarjuf", "~> 2.0"
 end
 
-if File.exists? "#{__FILE__}.local"
+if File.exist? "#{__FILE__}.local"
   eval(File.read("#{__FILE__}.local"), binding)
 end
 


### PR DESCRIPTION
In preparation for Puppet 8, which will likely use Ruby 3.2, this commit adds Ruby 3.2.0-preview2 to the Linux rspec tests matrix and the latest available Ruby version for Windows (3.1).