### PR TITLE
(HI-636) Updates Ubuntu GitHub Actions runners

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         cfg:
-          - {check: rake commits, os: ubuntu-18.04, ruby: '2.5'}
+          - {check: rake commits, os: ubuntu-latest, ruby: '2.5'}
 
     runs-on: ${{ matrix.cfg.os }}
     steps:

--- a/.github/workflows/rspec_tests.yaml
+++ b/.github/workflows/rspec_tests.yaml
@@ -13,9 +13,9 @@ jobs:
     strategy:
       matrix:
         cfg:
-          - {os: ubuntu-18.04, ruby: '2.5'}
-          - {os: ubuntu-18.04, ruby: '2.7'}
-          - {os: ubuntu-18.04, ruby: '3.2.0-preview2'}
+          - {os: ubuntu-latest, ruby: '2.5'}
+          - {os: ubuntu-latest, ruby: '2.7'}
+          - {os: ubuntu-latest, ruby: '3.2.0-preview2'}
           - {os: windows-2019, ruby: '2.5'}
           - {os: windows-2019, ruby: '2.7'}
           - {os: windows-2019, ruby: '3.1'}


### PR DESCRIPTION
GitHub is deprecating Ubuntu 18.04 runners on April 1, 2023. This commit switches all Ubuntu 18.04 used in GitHub Actions to ubuntu-latest (currently Ubuntu 20.04).