### PR TITLE
(maint) Use keyword arguments

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         cfg:
-          - {check: rake commits, os: ubuntu-latest, ruby: '2.5'}
+          - {check: rake commits, os: ubuntu-latest, ruby: '2.7'}
 
     runs-on: ${{ matrix.cfg.os }}
     steps:

--- a/.github/workflows/rspec_tests.yaml
+++ b/.github/workflows/rspec_tests.yaml
@@ -13,10 +13,8 @@ jobs:
     strategy:
       matrix:
         cfg:
-          - {os: ubuntu-latest, ruby: '2.5'}
           - {os: ubuntu-latest, ruby: '2.7'}
-          - {os: ubuntu-latest, ruby: '3.2.0-preview2'}
-          - {os: windows-2019, ruby: '2.5'}
+          - {os: ubuntu-latest, ruby: '3.2.0'}
           - {os: windows-2019, ruby: '2.7'}
           - {os: windows-2019, ruby: '3.1'}
 

--- a/install.rb
+++ b/install.rb
@@ -51,7 +51,7 @@ def do_configs(configs, target, strip = 'ext/')
   Dir.mkdir(target) unless File.directory? target
   configs.each do |cf|
     ocf = File.join(InstallOptions.config_dir, cf.gsub(/#{strip}/, ''))
-    install(cf, ocf, {:mode => 0644, :preserve => true, :verbose => true})
+    install(cf, ocf, mode: 0644, preserve: true, verbose: true)
   end
 end
 
@@ -67,9 +67,9 @@ def do_libs(libs, strip = 'lib/')
   libs.each do |lf|
     olf = File.join(InstallOptions.site_dir, lf.gsub(/#{strip}/, ''))
     op = File.dirname(olf)
-    makedirs(op, {:mode => 0755, :verbose => true})
+    makedirs(op, mode: 0755, verbose: true)
     chmod(0755, op)
-    install(lf, olf, {:mode => 0644, :preserve => true, :verbose => true})
+    install(lf, olf, mode: 0644, preserve: true, verbose: true)
   end
 end
 
@@ -77,9 +77,9 @@ def do_man(man, strip = 'man/')
   man.each do |mf|
     omf = File.join(InstallOptions.man_dir, mf.gsub(/#{strip}/, ''))
     om = File.dirname(omf)
-    makedirs(om, {:mode => 0755, :verbose => true})
+    makedirs(om, mode: 0755, verbose: true)
     chmod(0755, om)
-    install(mf, omf, {:mode => 0644, :preserve => true, :verbose => true})
+    install(mf, omf, mode: 0644, preserve: true, verbose: true)
 
     gzip = %x{which gzip}
     gzip.chomp!


### PR DESCRIPTION
FileUtils in ruby 3.x doesn't accept passing args as a hash.