### PR TITLE
feat: support YAML anchors and aliases

### DIFF
--- a/lib/hiera/backend/yaml_backend.rb
+++ b/lib/hiera/backend/yaml_backend.rb
@@ -16,7 +16,7 @@ class Hiera
 
         Backend.datasourcefiles(:yaml, scope, "yaml", order_override) do |source, yamlfile|
           data = @cache.read_file(yamlfile, Hash) do |data|
-            YAML.load(data) || {}
+            YAML.safe_load(data, aliases: true) || {}
           end
 
           next if data.empty?

--- a/spec/unit/fixtures/aliases/config/hiera.yaml
+++ b/spec/unit/fixtures/aliases/config/hiera.yaml
@@ -1,0 +1,5 @@
+:backends:
+  - yaml
+
+:hierarchy:
+  - common

--- a/spec/unit/fixtures/aliases/data/common.yaml
+++ b/spec/unit/fixtures/aliases/data/common.yaml
@@ -1,0 +1,29 @@
+---
+
+# string alias
+hello: &hello 'hi'
+greeting:
+  hello: *hello
+
+# block alias
+defaults: &defaults
+  foo: 'bar'
+  sub:
+    val: 1
+
+config:
+  <<: *defaults
+  baz: 'baz'
+
+# alias from alias
+bar: &bar
+  foo: 'foo'
+  baz: 'bazbaz'
+location:
+  planet: 'earth'
+  bar: &newalias
+    <<: *bar
+    baz: 'notbaz'
+new_location:
+  planet: 'mars'
+  bar: *newalias  #new_location.bar.baz is 'notbaz'

--- a/spec/unit/interpolate_spec.rb
+++ b/spec/unit/interpolate_spec.rb
@@ -239,4 +239,22 @@ describe "Hiera" do
       expect{ hiera.lookup('foo', nil, {}) }.to raise_error(Hiera::InterpolationLoop, "Lookup recursion detected in [hiera('role')]")
     end
   end
+
+  context 'when using yaml anchors and aliases' do
+    let!(:fixtures) { File.join(HieraSpec::FIXTURE_DIR, 'aliases') }
+
+    it 'should handle simple aliases' do
+      expect(hiera.lookup('greeting.hello', nil, {})).to eq('hi')
+    end
+
+    it 'should handle block aliases' do
+      expect(hiera.lookup('config.foo', nil, {})).to eq('bar')
+      expect(hiera.lookup('config.sub.val', nil, {})).to eq(1)
+    end
+
+    it 'should even allow aliases from aliases' do
+      expect(hiera.lookup('new_location.bar.baz', nil, {})).to eq('notbaz')
+      expect(hiera.lookup('new_location.bar.foo', nil, {})).to eq('foo')
+    end
+  end
 end


### PR DESCRIPTION
This allows to DRY up code in the YAML config files.

- [usage](https://www.yaml.info/learn/index.html)
- [spec](https://yaml.org/spec/1.2-old/spec.html#id2786196)